### PR TITLE
Use variables set by find_package(CURL)

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -33,7 +33,8 @@ target_include_directories(${PROJECT_NAME} PUBLIC
     $<INSTALL_INTERFACE:include>)
 
 find_package(CURL REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE curl)
+target_link_libraries(${PROJECT_NAME} PRIVATE ${CURL_LIBRARIES})
+target_include_directories(${PROJECT_NAME} PRIVATE ${CURL_INCLUDE_DIRS})
 
 if(HAVE_BACKTRACE)
     target_compile_definitions(${PROJECT_NAME} PRIVATE -DHAVE_BACKTRACE)


### PR DESCRIPTION
Without explicitly linking to , the linker will always pick up libcurl from the system path, which
might not be what we want if we built libcurl from source and installed it elsewhere, for example.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
