### PR TITLE
More resilience  with older libcurl versions

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -50,7 +50,6 @@ target_compile_options(${PROJECT_NAME} PRIVATE
     "-Wconversion"
     "-Wno-sign-conversion")
 
-#TODO: make this a CMake option/variable
 if (LOG_VERBOSITY)
     target_compile_definitions(${PROJECT_NAME} PRIVATE "-DAWS_LAMBDA_LOG=${LOG_VERBOSITY}")
 elseif(CMAKE_BUILD_TYPE STREQUAL Debug)

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -198,6 +198,8 @@ void runtime::set_curl_next_options()
     curl_easy_setopt(m_curl_handle, CURLOPT_CONNECTTIMEOUT, 1L);
     curl_easy_setopt(m_curl_handle, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(m_curl_handle, CURLOPT_TCP_NODELAY, 1L);
+    curl_easy_setopt(m_curl_handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+
     curl_easy_setopt(m_curl_handle, CURLOPT_HTTPGET, 1L);
     curl_easy_setopt(m_curl_handle, CURLOPT_URL, m_endpoints[Endpoints::NEXT].c_str());
 
@@ -217,6 +219,8 @@ void runtime::set_curl_post_result_options()
     curl_easy_setopt(m_curl_handle, CURLOPT_CONNECTTIMEOUT, 1L);
     curl_easy_setopt(m_curl_handle, CURLOPT_NOSIGNAL, 1L);
     curl_easy_setopt(m_curl_handle, CURLOPT_TCP_NODELAY, 1L);
+    curl_easy_setopt(m_curl_handle, CURLOPT_HTTP_VERSION, CURL_HTTP_VERSION_1_1);
+
     curl_easy_setopt(m_curl_handle, CURLOPT_POST, 1L);
     curl_easy_setopt(m_curl_handle, CURLOPT_READFUNCTION, read_data);
     curl_easy_setopt(m_curl_handle, CURLOPT_WRITEFUNCTION, write_data);

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -234,7 +234,6 @@ void runtime::set_curl_post_result_options()
 
 runtime::next_outcome runtime::get_next()
 {
-
     http::response resp;
     set_curl_next_options();
     curl_easy_setopt(m_curl_handle, CURLOPT_WRITEDATA, &resp);
@@ -412,8 +411,7 @@ void run_handler(std::function<invocation_response(invocation_request const&)> c
         const auto next_outcome = rt.get_next();
         if (!next_outcome.is_success()) {
             if (next_outcome.get_failure() == aws::http::response_code::REQUEST_NOT_MADE) {
-                logging::log_error(LOG_TAG, "Failed to send HTTP request to retrieve next task.");
-                return;
+                continue;
             }
 
             logging::log_info(

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -19,6 +19,7 @@
 #include "aws/http/response.h"
 
 #include <curl/curl.h>
+#include <curl/curlver.h>
 #include <climits> // for ULONG_MAX
 #include <cassert>
 #include <chrono>
@@ -445,6 +446,11 @@ void run_handler(std::function<invocation_response(invocation_request const&)> c
                 return; // TODO: implement a better retry strategy
             }
         }
+    }
+
+    if (retries == max_retries) {
+        logging::log_error(
+            LOG_TAG, "Exhausted all retries. This is probably a bug in libcurl v" LIBCURL_VERSION " Exiting!");
     }
 }
 


### PR DESCRIPTION
- On some older versions of libcurll - v7.35 which comes with Ubuntu 14.04 LTS - the http request to /next fails between Lambda invocations. Mitigate this by ignoring that error and retrying the request. This should have no negative effect on newer libraries.

- Explicitly set the http protocol version to 1.1 because on newer libcurl versions the default protocol is set to http/2 with TLS. See https://curl.haxx.se/libcurl/c/CURLOPT_HTTP_VERSION.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
