### PR TITLE
More efficient packaging when NO_LIBC is specified.

### DIFF
--- a/ci/codebuild/amazonlinux-2017.03.yml
+++ b/ci/codebuild/amazonlinux-2017.03.yml
@@ -10,7 +10,8 @@ phases:
     commands:
       - echo Build started on `date`
       - ci/codebuild/build.sh -DENABLE_TESTS=ON
-      - ci/codebuild/run-tests.sh
+      - ci/codebuild/run-tests.sh  aws-lambda-package-lambda-test-fun
+      - ci/codebuild/run-tests.sh  aws-lambda-package-lambda-test-fun-no-glibc
   post_build:
     commands:
       - echo Build completed on `date`

--- a/ci/codebuild/run-tests.sh
+++ b/ci/codebuild/run-tests.sh
@@ -4,7 +4,8 @@ set -euo pipefail
 
 cd $CODEBUILD_SRC_DIR
 cd build
-ninja aws-lambda-package-lambda-test-fun
+rm -rf *.zip
+ninja $1
 aws s3 cp tests/resources/lambda-test-fun.zip s3://aws-lambda-cpp-tests/lambda-test-fun.zip
 ctest --output-on-failure
 

--- a/packaging/packager
+++ b/packaging/packager
@@ -122,7 +122,7 @@ bootstrap_script_no_libc=$(cat <<EOF
 #!/bin/bash
 set -euo pipefail
 export AWS_EXECUTION_ENV=lambda-cpp
-export LD_LIBRARY_PATH=\$LAMBDA_TASK_ROOT/lib:\$LD_LIBRARY_PATH
+export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$LAMBDA_TASK_ROOT/lib
 exec \$LAMBDA_TASK_ROOT/bin/$PKG_BIN_FILENAME \${_HANDLER}
 EOF
 )

--- a/packaging/packager
+++ b/packaging/packager
@@ -113,6 +113,7 @@ done
 bootstrap_script=$(cat <<EOF
 #!/bin/bash
 set -euo pipefail
+export AWS_EXECUTION_ENV=lambda-cpp
 exec \$LAMBDA_TASK_ROOT/lib/$PKG_LD --library-path \$LAMBDA_TASK_ROOT/lib \$LAMBDA_TASK_ROOT/bin/$PKG_BIN_FILENAME \${_HANDLER}
 EOF
 )
@@ -120,6 +121,7 @@ EOF
 bootstrap_script_no_libc=$(cat <<EOF
 #!/bin/bash
 set -euo pipefail
+export AWS_EXECUTION_ENV=lambda-cpp
 export LD_LIBRARY_PATH=\$LAMBDA_TASK_ROOT/lib:\$LD_LIBRARY_PATH
 exec \$LAMBDA_TASK_ROOT/bin/$PKG_BIN_FILENAME \${_HANDLER}
 EOF

--- a/packaging/packager
+++ b/packaging/packager
@@ -77,10 +77,16 @@ function package_libc_via_rpm() {
 
 PKG_BIN_FILENAME=`basename "$PKG_BIN_PATH"`
 PKG_DIR=tmp
+PKG_LD=""
 
-list=`ldd "$PKG_BIN_PATH" | awk '{print $(NF-1)}'`
+list=$(ldd "$PKG_BIN_PATH" | awk '{print $(NF-1)}')
+libc_libs=()
+libc_libs+=$(package_libc_via_dpkg)
+libc_libs+=$(package_libc_via_rpm)
+libc_libs+=$(package_libc_via_pacman)
+
 if [[ $INCLUDE_LIBC == true ]]; then
-    list="$list $(package_libc_via_dpkg) $(package_libc_via_rpm) $(package_libc_via_pacman)"
+    list+=$libc_libs;
 fi
 
 mkdir -p "$PKG_DIR/bin" "$PKG_DIR/lib"
@@ -90,6 +96,13 @@ do
     if [[ ! -f $i ]]; then # ignore linux-vdso.so.1
         continue
     fi
+
+    if [[ $INCLUDE_LIBC == false ]]; then
+        matched=$(echo $libc_libs | grep --count $i) || true # prevent the non-zero exit status from terminating the script
+        if [ $matched -gt 0 ]; then
+            continue
+        fi
+    fi
     cp $i $PKG_DIR/lib
     filename=`basename $i`
     if [[ -z "${filename##ld-*}" ]]; then
@@ -97,25 +110,26 @@ do
     fi
 done
 
-bootstrap_script="#!/bin/bash\n
-\n
-set -euo pipefail\n
-\n
-exec \$LAMBDA_TASK_ROOT/lib/$PKG_LD --library-path \$LAMBDA_TASK_ROOT/lib \$LAMBDA_TASK_ROOT/bin/$PKG_BIN_FILENAME \${_HANDLER}\n
-"
+bootstrap_script=$(cat <<EOF
+#!/bin/bash
+set -euo pipefail
+exec \$LAMBDA_TASK_ROOT/lib/$PKG_LD --library-path \$LAMBDA_TASK_ROOT/lib \$LAMBDA_TASK_ROOT/bin/$PKG_BIN_FILENAME \${_HANDLER}
+EOF
+)
 
-bootstrap_script_no_libc="#!/bin/bash\n
-\n
-set -euo pipefail\n
-\n
-exec \$LAMBDA_TASK_ROOT/lib/$PKG_LD --library-path \$LD_LIBRARY_PATH:\$LAMBDA_TASK_ROOT/lib \$LAMBDA_TASK_ROOT/bin/$PKG_BIN_FILENAME \${_HANDLER}\n
-"
+bootstrap_script_no_libc=$(cat <<EOF
+#!/bin/bash
+set -euo pipefail
+export LD_LIBRARY_PATH=\$LAMBDA_TASK_ROOT/lib:\$LD_LIBRARY_PATH
+exec \$LAMBDA_TASK_ROOT/bin/$PKG_BIN_FILENAME \${_HANDLER}
+EOF
+)
 
 cp "$PKG_BIN_PATH" "$PKG_DIR/bin"
 if [[ $INCLUDE_LIBC == true ]]; then
-    echo -e $bootstrap_script > "$PKG_DIR/bootstrap"
+    echo -e "$bootstrap_script" > "$PKG_DIR/bootstrap"
 else
-    echo -e $bootstrap_script_no_libc > "$PKG_DIR/bootstrap"
+    echo -e "$bootstrap_script_no_libc" > "$PKG_DIR/bootstrap"
 fi
 chmod +x "$PKG_DIR/bootstrap"
 # some shenanigans to create the right layout in the zip file without extraneous directories

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -23,7 +23,6 @@
 #include <climits> // for ULONG_MAX
 #include <cassert>
 #include <chrono>
-#include <algorithm>
 #include <array>
 #include <cstdlib> // for strtoul
 

--- a/tests/resources/CMakeLists.txt
+++ b/tests/resources/CMakeLists.txt
@@ -9,3 +9,6 @@ add_custom_target(aws-lambda-package-lambda-test-fun
     COMMAND "${CMAKE_SOURCE_DIR}/packaging/packager" "${CMAKE_CURRENT_BINARY_DIR}/lambda-test-fun"
     DEPENDS ${PROJECT_NAME})
 
+add_custom_target(aws-lambda-package-lambda-test-fun-no-glibc
+    COMMAND "${CMAKE_SOURCE_DIR}/packaging/packager" -d "${CMAKE_CURRENT_BINARY_DIR}/lambda-test-fun"
+    DEPENDS ${PROJECT_NAME})


### PR DESCRIPTION
*Description of changes:*
- When NO_LIBC is used, exclude the libc libraries that are directly linked to the binary and show up in the ldd result.
- Add a test that utilizes the packaging script with NO_LIBC
- Set the AWS_EXECUTION_ENV variable to 'lambda-cpp' to show up in the SDK metrics
- (bonus) Remove the 'algorithm' header file. It's not needed.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
