### PR TITLE
Add User-Agent information

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.5)
 set(CMAKE_CXX_STANDARD 11)
 project(aws-lambda-runtime
-    VERSION 0.1
+    VERSION 0.1.0
     LANGUAGES CXX)
 
 option(ENABLE_TESTS "Enables building the test project, requires AWS C++ SDK." OFF)
@@ -26,6 +26,7 @@ check_cxx_compiler_flag("-Wl,-flto" LTO_CAPABLE)
 add_library(${PROJECT_NAME}
     "src/logging.cpp"
     "src/runtime.cpp"
+    "${CMAKE_CURRENT_BINARY_DIR}/version.cpp"
     )
 
 target_include_directories(${PROJECT_NAME} PUBLIC
@@ -51,11 +52,11 @@ target_compile_options(${PROJECT_NAME} PRIVATE
     "-Wno-sign-conversion")
 
 if (LOG_VERBOSITY)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE "-DAWS_LAMBDA_LOG=${LOG_VERBOSITY}")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE "AWS_LAMBDA_LOG=${LOG_VERBOSITY}")
 elseif(CMAKE_BUILD_TYPE STREQUAL Debug)
-    target_compile_definitions(${PROJECT_NAME} PRIVATE "-DAWS_LAMBDA_LOG=3")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE "AWS_LAMBDA_LOG=3")
 else ()
-    target_compile_definitions(${PROJECT_NAME} PRIVATE "-DAWS_LAMBDA_LOG=0")
+    target_compile_definitions(${PROJECT_NAME} PRIVATE "AWS_LAMBDA_LOG=0")
 endif()
 
 if ((BUILD_SHARED_LIBS) AND (LTO_CAPABLE))
@@ -69,8 +70,14 @@ if (ENABLE_TESTS)
     add_subdirectory(tests)
 endif()
 
+#versioning
+configure_file(
+    "${CMAKE_CURRENT_SOURCE_DIR}/src/version.cpp.in"
+    "${CMAKE_CURRENT_BINARY_DIR}/version.cpp"
+    NEWLINE_STYLE LF)
+
 # installation
-install(FILES "include/aws/lambda-runtime/runtime.h"
+install(FILES "include/aws/lambda-runtime/runtime.h" "include/aws/lambda-runtime/version.h"
     DESTINATION "include/aws/lambda-runtime")
 
 install(FILES "include/aws/logging/logging.h"

--- a/ci/codebuild/build-cpp-sdk.sh
+++ b/ci/codebuild/build-cpp-sdk.sh
@@ -11,7 +11,7 @@ cmake .. -GNinja -DBUILD_ONLY="lambda" \
     -DCMAKE_BUILD_TYPE=Release \
     -DENABLE_UNITY_BUILD=ON \
     -DBUILD_SHARED_LIBS=ON \
-    -DAUTORUN_UNIT_TESTS=OFF \
+    -DENABLE_TESTING=OFF \
     -DCMAKE_INSTALL_PREFIX=/install $@
 ninja
 ninja install

--- a/include/aws/lambda-runtime/version.h
+++ b/include/aws/lambda-runtime/version.h
@@ -1,0 +1,41 @@
+#pragma once
+/*
+ * Copyright 2018-present Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+namespace aws {
+namespace lambda_runtime {
+
+/**
+ * Returns the major component of the library version.
+ */
+unsigned get_version_major();
+
+/**
+ * Returns the minor component of the library version.
+ */
+unsigned get_version_minor();
+
+/**
+ * Returns the patch component of the library version.
+ */
+unsigned get_version_patch();
+
+/**
+ * Returns the semantic version of the library in the form Major.Minor.Patch
+ */
+char const* get_version();
+
+} // namespace lambda_runtime
+} // namespace aws

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -106,7 +106,7 @@ static size_t write_header(char* ptr, size_t size, size_t nmemb, void* userdata)
     return size * nmemb;
 }
 
-static std::string get_user_agent_header()
+static std::string const& get_user_agent_header()
 {
     static std::string user_agent = std::string("User-Agent: AWS_Lambda_Cpp/") + get_version();
     return user_agent;

--- a/src/version.cpp.in
+++ b/src/version.cpp.in
@@ -1,0 +1,48 @@
+/*
+ * Copyright 2018-present Amazon.com, Inc. or its affiliates. All Rights Reserved.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License").
+ * You may not use this file except in compliance with the License.
+ * A copy of the License is located at
+ *
+ *  http://aws.amazon.com/apache2.0
+ *
+ * or in the "license" file accompanying this file. This file is distributed
+ * on an "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either
+ * express or implied. See the License for the specific language governing
+ * permissions and limitations under the License.
+ */
+
+#define AWS_LAMBDA_RUNTIME_API __attribute__((visibility("default")))
+
+namespace aws {
+namespace lambda_runtime {
+
+/* clang-format off */
+AWS_LAMBDA_RUNTIME_API
+unsigned get_version_major()
+{
+    return @PROJECT_VERSION_MAJOR@;
+}
+
+AWS_LAMBDA_RUNTIME_API
+unsigned get_version_minor()
+{
+    return @PROJECT_VERSION_MINOR@;
+}
+
+AWS_LAMBDA_RUNTIME_API
+unsigned get_version_patch()
+{
+    return @PROJECT_VERSION_PATCH@;
+}
+/* clang-format on */
+
+AWS_LAMBDA_RUNTIME_API
+char const* get_version()
+{
+    return "@PROJECT_VERSION@";
+}
+
+} // namespace lambda_runtime
+} // namespace aws

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -4,13 +4,12 @@ find_package(GTest REQUIRED)
 
 add_executable(${PROJECT_NAME}
     main.cpp
-    runtime_tests.cpp)
+    runtime_tests.cpp
+    version_tests.cpp)
 
 target_link_libraries(${PROJECT_NAME} PRIVATE ${AWSSDK_LINK_LIBRARIES} aws-lambda-runtime GTest::GTest)
 
-# gtest_discover_tests(${PROJECT_NAME}) Can't use this until CMake 3.10 :(
-# gtest_add_tests(TARGET ${PROJECT_NAME} runtime_tests.cpp)
-GTEST_ADD_TESTS(${PROJECT_NAME} "" AUTO)
+gtest_discover_tests(${PROJECT_NAME}) # requires CMake 3.10 or later
 
 add_subdirectory(resources)
 

--- a/tests/version_tests.cpp
+++ b/tests/version_tests.cpp
@@ -1,0 +1,22 @@
+#include <gtest/gtest.h>
+#include <aws/lambda-runtime/version.h>
+
+using namespace aws::lambda_runtime;
+
+TEST(VersionTests, get_version_major)
+{
+    auto version = get_version_major();
+    ASSERT_EQ(0, version);
+}
+
+TEST(VersionTests, get_version_minor)
+{
+    auto version = get_version_minor();
+    ASSERT_GE(version, 1);
+}
+
+TEST(VersionTests, get_version_patch)
+{
+    auto version = get_version_patch();
+    ASSERT_GE(version, 0);
+}


### PR DESCRIPTION
Send a user-agent http header when talking to Lambda's http server.
This is important for collecting usage metrics.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
