### PR TITLE
Handle rpm on Debian-based distributions

### DIFF
--- a/packaging/packager
+++ b/packaging/packager
@@ -65,13 +65,17 @@ function package_libc_via_pacman {
 
 function package_libc_via_dpkg() {
     if type dpkg-query > /dev/null 2>&1; then
-        dpkg-query --listfiles libc6 | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+        if [ $(dpkg-query --listfiles libc6 | wc -l) -gt 0 ]; then
+            dpkg-query --listfiles libc6 | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+        fi
     fi
 }
 
 function package_libc_via_rpm() {
     if type rpm > /dev/null 2>&1; then
-        rpm --query --list glibc | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+       if [ $(rpm --query --list --quiet glibc | wc -l) -gt 0 ]; then
+           rpm --query --list glibc | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+       fi
     fi
 }
 


### PR DESCRIPTION
RPM can be installed as a dependency (or separately) in Debian-based
distros that ultimately use dpkg. In those cases, the packager script
should handle the case in which querying rpm returns nothing.

Fixes https://github.com/awslabs/aws-lambda-cpp/issues/15

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
