### PR TITLE
Reduce bloat in the output zip package

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -87,9 +87,9 @@ install(FILES "include/aws/logging/logging.h"
 
 install(TARGETS ${PROJECT_NAME}
     EXPORT ${PROJECT_NAME}-targets
-    ARCHIVE DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-    LIBRARY DESTINATION ${CMAKE_INSTALL_PREFIX}/lib
-    RUNTIME DESTINATION ${CMAKE_INSTALL_PREFIX}/bin)
+    ARCHIVE DESTINATION lib
+    LIBRARY DESTINATION lib
+    RUNTIME DESTINATION bin)
 
 configure_file("${CMAKE_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
@@ -98,12 +98,12 @@ configure_file("${CMAKE_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake"
 export(EXPORT "${PROJECT_NAME}-targets" NAMESPACE AWS::)
 
 install(EXPORT "${PROJECT_NAME}-targets"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}/cmake/"
+    DESTINATION "lib/${PROJECT_NAME}/cmake/"
     NAMESPACE AWS::)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}/cmake/")
+    DESTINATION "lib/${PROJECT_NAME}/cmake/")
 
 install(PROGRAMS "${CMAKE_SOURCE_DIR}/packaging/packager"
-    DESTINATION "${CMAKE_INSTALL_PREFIX}/lib/${PROJECT_NAME}/cmake/")
+    DESTINATION "lib/${PROJECT_NAME}/cmake/")
 

--- a/ci/codebuild/build.sh
+++ b/ci/codebuild/build.sh
@@ -8,4 +8,4 @@ mkdir build
 cd build
 cmake .. -GNinja -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/install $@
 ninja
-
+ninja install

--- a/packaging/packager
+++ b/packaging/packager
@@ -89,10 +89,6 @@ libc_libs+=$(package_libc_via_dpkg)
 libc_libs+=$(package_libc_via_rpm)
 libc_libs+=$(package_libc_via_pacman)
 
-if [[ $INCLUDE_LIBC == true ]]; then
-    list+=$libc_libs;
-fi
-
 mkdir -p "$PKG_DIR/bin" "$PKG_DIR/lib"
 
 for i in $list
@@ -101,18 +97,25 @@ do
         continue
     fi
 
-    if [[ $INCLUDE_LIBC == false ]]; then
-        matched=$(echo $libc_libs | grep --count $i) || true # prevent the non-zero exit status from terminating the script
-        if [ $matched -gt 0 ]; then
-            continue
-        fi
+    # Do not copy libc files which are directly linked
+    matched=$(echo $libc_libs | grep --count $i) || true # prevent the non-zero exit status from terminating the script
+    if [ $matched -gt 0 ]; then
+        continue
     fi
+
     cp $i $PKG_DIR/lib
     filename=`basename $i`
     if [[ -z "${filename##ld-*}" ]]; then
         PKG_LD=$filename # Use this file as the loader
     fi
 done
+
+if [[ $INCLUDE_LIBC == true ]]; then
+    for i in $libc_libs
+    do
+        cp --no-dereference $i $PKG_DIR/lib
+    done
+fi
 
 bootstrap_script=$(cat <<EOF
 #!/bin/bash
@@ -140,7 +143,7 @@ fi
 chmod +x "$PKG_DIR/bootstrap"
 # some shenanigans to create the right layout in the zip file without extraneous directories
 pushd "$PKG_DIR" > /dev/null
-zip -r $PKG_BIN_FILENAME.zip *
+zip -yr $PKG_BIN_FILENAME.zip *
 ORIGIN_DIR=$(dirs -l +1)
 mv $PKG_BIN_FILENAME.zip $ORIGIN_DIR
 popd > /dev/null


### PR DESCRIPTION
### Reduce bloat in the output zip package
Avoid dereferencing symlinks when iterating over libc files. Otherwise,
we end up with two copies of the same file, one with the symlink name
and the actual file.

Files which are directly linked to the executable are listed (in the
ldd output) by their symlink name. Those are fine to dereference
because there's only a single mention of them. The actual (dereferenced)
file is not listed in output from ldd.

### Use relative paths for CMake package config files
Using relative paths in the 'install' command results in a CMake
target file that does not contain hard-coded/machine dependent absolute
paths to the binary library file. This is useful when building and
installing the library on one machine then copying the installed files
to be consumed on another machine. A common practice when using
distributed builds.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
