### PR TITLE
Fix off-by-one bug when rpm is installed on non-RHEL systems

### DIFF
--- a/packaging/packager
+++ b/packaging/packager
@@ -73,7 +73,7 @@ function package_libc_via_dpkg() {
 
 function package_libc_via_rpm() {
     if type rpm > /dev/null 2>&1; then
-       if [ $(rpm --query --list glibc | wc -l) -gt 0 ]; then
+       if [ $(rpm --query --list glibc | wc -l) -gt 1 ]; then
            rpm --query --list glibc | sed -E '/\.so$|\.so\.[0-9]+$/!d'
        fi
     fi


### PR DESCRIPTION

In 02c35e485b we removed the --quiet flag because it printed nothing on RHEL systems regardless if the package existed or not. However, on Debian systems without --quiet we get at least a single line if the package is not installed "package glibc is not installed".
This patch fixes this off by one error and fixes issue #41 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
