### PR TITLE
Remove an extra colon that caused array lookup to fail

### DIFF
--- a/packaging/packager
+++ b/packaging/packager
@@ -85,7 +85,7 @@ function package_libc_via_rpm() {
 function hasElement() {
     local el key=$1
     shift
-    for el in "$@":
+    for el in "$@"
     do
         [[ "$el" == "$key" ]] && return 0
     done


### PR DESCRIPTION
Fixes issue https://github.com/awslabs/aws-lambda-cpp/issues/45


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
