### PR TITLE
Add format attribute on logging functions

### DIFF
--- a/include/aws/logging/logging.h
+++ b/include/aws/logging/logging.h
@@ -27,8 +27,7 @@ enum class verbosity {
 
 void log(verbosity v, char const* tag, char const* msg, va_list args);
 
-[[gnu::format(printf, 2, 3)]]
-static inline void log_error(char const* tag, char const* msg, ...)
+[[gnu::format(printf, 2, 3)]] static inline void log_error(char const* tag, char const* msg, ...)
 {
     va_list args;
     va_start(args, msg);
@@ -38,8 +37,7 @@ static inline void log_error(char const* tag, char const* msg, ...)
     (void)msg;
 }
 
-[[gnu::format(printf, 2, 3)]]
-static inline void log_info(char const* tag, char const* msg, ...)
+[[gnu::format(printf, 2, 3)]] static inline void log_info(char const* tag, char const* msg, ...)
 {
 #if AWS_LAMBDA_LOG >= 1
     va_list args;
@@ -52,8 +50,7 @@ static inline void log_info(char const* tag, char const* msg, ...)
 #endif
 }
 
-[[gnu::format(printf, 2, 3)]]
-static inline void log_debug(char const* tag, char const* msg, ...)
+[[gnu::format(printf, 2, 3)]] static inline void log_debug(char const* tag, char const* msg, ...)
 {
 #if AWS_LAMBDA_LOG >= 2
     va_list args;

--- a/include/aws/logging/logging.h
+++ b/include/aws/logging/logging.h
@@ -27,6 +27,7 @@ enum class verbosity {
 
 void log(verbosity v, char const* tag, char const* msg, va_list args);
 
+[[gnu::format(printf, 2, 3)]]
 static inline void log_error(char const* tag, char const* msg, ...)
 {
     va_list args;
@@ -37,6 +38,7 @@ static inline void log_error(char const* tag, char const* msg, ...)
     (void)msg;
 }
 
+[[gnu::format(printf, 2, 3)]]
 static inline void log_info(char const* tag, char const* msg, ...)
 {
 #if AWS_LAMBDA_LOG >= 1
@@ -50,6 +52,7 @@ static inline void log_info(char const* tag, char const* msg, ...)
 #endif
 }
 
+[[gnu::format(printf, 2, 3)]]
 static inline void log_debug(char const* tag, char const* msg, ...)
 {
 #if AWS_LAMBDA_LOG >= 2


### PR DESCRIPTION
This prevents using the wrong format specifier.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
