### PR TITLE
Fix awssdk cmake args in READMEs

### DIFF
--- a/examples/dynamodb/README.md
+++ b/examples/dynamodb/README.md
@@ -13,7 +13,7 @@ $ git clone https://github.com/aws/aws-sdk-cpp.git
 $ cd aws-sdk-cpp
 $ mkdir build
 $ cd build
-$ cmake .. -DBUILD_ONLY="s3" \
+$ cmake .. -DBUILD_ONLY="dynamodb" \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=OFF \
   -DENABLE_UNITY_BUILD=ON \


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:*
In order for the sample code to compile in my AL Docker environment, I had to add `core` to the list of `BUILD_ONLY` awssdk dependencies.

Also, I am pretty sure the dynamodb example needs the dynamodb client, not s3 :)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
