### PR TITLE
move runtime class to runtime.h

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -82,7 +82,10 @@ configure_file(
     NEWLINE_STYLE LF)
 
 # installation
-install(FILES "include/aws/lambda-runtime/runtime.h" "include/aws/lambda-runtime/version.h"
+install(FILES "include/aws/http/response.h"
+    DESTINATION "include/aws/http")
+
+install(FILES "include/aws/lambda-runtime/runtime.h" "include/aws/lambda-runtime/version.h" "include/aws/lambda-runtime/outcome.h"
     DESTINATION "include/aws/lambda-runtime")
 
 install(FILES "include/aws/logging/logging.h"

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -145,45 +145,6 @@ static int rt_curl_debug_callback(CURL* handle, curl_infotype type, char* data, 
 }
 #endif
 
-struct no_result {
-};
-
-class runtime {
-public:
-    using next_outcome = aws::lambda_runtime::outcome<invocation_request, aws::http::response_code>;
-    using post_outcome = aws::lambda_runtime::outcome<no_result, aws::http::response_code>;
-
-    runtime(std::string const& endpoint);
-    ~runtime();
-
-    /**
-     * Ask lambda for an invocation.
-     */
-    next_outcome get_next();
-
-    /**
-     * Tells lambda that the function has succeeded.
-     */
-    post_outcome post_success(std::string const& request_id, invocation_response const& handler_response);
-
-    /**
-     * Tells lambda that the function has failed.
-     */
-    post_outcome post_failure(std::string const& request_id, invocation_response const& handler_response);
-
-private:
-    void set_curl_next_options();
-    void set_curl_post_result_options();
-    post_outcome do_post(
-        std::string const& url,
-        std::string const& request_id,
-        invocation_response const& handler_response);
-
-private:
-    std::array<std::string const, 3> const m_endpoints;
-    CURL* const m_curl_handle;
-};
-
 runtime::runtime(std::string const& endpoint)
     : m_endpoints{{endpoint + "/2018-06-01/runtime/init/error",
                    endpoint + "/2018-06-01/runtime/invocation/next",


### PR DESCRIPTION
*Description of changes:*

Moves the runtime class to a public header. This is useful so that it can be used standalone in other C++ runtime projects.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
