### PR TITLE
disable use of an http proxy

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -179,6 +179,8 @@ void runtime::set_curl_next_options()
     curl_easy_setopt(m_curl_handle, CURLOPT_WRITEFUNCTION, write_data);
     curl_easy_setopt(m_curl_handle, CURLOPT_HEADERFUNCTION, write_header);
 
+    curl_easy_setopt(m_curl_handle, CURLOPT_PROXY, "");
+
 #ifndef NDEBUG
     curl_easy_setopt(m_curl_handle, CURLOPT_VERBOSE, 1);
     curl_easy_setopt(m_curl_handle, CURLOPT_DEBUGFUNCTION, rt_curl_debug_callback);
@@ -198,6 +200,8 @@ void runtime::set_curl_post_result_options()
     curl_easy_setopt(m_curl_handle, CURLOPT_READFUNCTION, read_data);
     curl_easy_setopt(m_curl_handle, CURLOPT_WRITEFUNCTION, write_data);
     curl_easy_setopt(m_curl_handle, CURLOPT_HEADERFUNCTION, write_header);
+
+    curl_easy_setopt(m_curl_handle, CURLOPT_PROXY, "");
 
 #ifndef NDEBUG
     curl_easy_setopt(m_curl_handle, CURLOPT_VERBOSE, 1);


### PR DESCRIPTION
*Description of changes:*

`http_proxy` is an attractive environment variable to use. But libcurl will respect it unless we tell it not to! This change prevents the runtime client from inadvertently sending requests to an address that won't respond.

ref: https://curl.haxx.se/libcurl/c/CURLOPT_PROXY.html

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
