### PR TITLE
add arbitrary payload constructor for invocation_response

### DIFF
--- a/include/aws/lambda-runtime/runtime.h
+++ b/include/aws/lambda-runtime/runtime.h
@@ -92,6 +92,12 @@ private:
     invocation_response() = default;
 
 public:
+    invocation_response(std::string const& payload, std::string const& content_type, bool success):
+        m_payload(payload),
+        m_content_type(content_type),
+        m_success(success)
+    {}
+
     /**
      * Create a successful invocation response with the given payload and content-type.
      */

--- a/include/aws/lambda-runtime/runtime.h
+++ b/include/aws/lambda-runtime/runtime.h
@@ -92,11 +92,10 @@ private:
     invocation_response() = default;
 
 public:
-    invocation_response(std::string const& payload, std::string const& content_type, bool success):
-        m_payload(payload),
-        m_content_type(content_type),
-        m_success(success)
-    {}
+    invocation_response(std::string const& payload, std::string const& content_type, bool success)
+        : m_payload(payload), m_content_type(content_type), m_success(success)
+    {
+    }
 
     /**
      * Create a successful invocation response with the given payload and content-type.


### PR DESCRIPTION
*Description of changes:*

`invocation_response::failure` doesn't allow for arbitrary payloads. To support clients that need to control the entire error response body (ex: adding a stack trace), i've added a new constructor.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
