### PR TITLE
A few CMake improvements

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 set(CMAKE_CXX_STANDARD 11)
 project(aws-lambda-runtime
     VERSION 0.2.4
@@ -6,9 +6,7 @@ project(aws-lambda-runtime
 
 option(ENABLE_TESTS "Enables building the test project, requires AWS C++ SDK." OFF)
 
-include(CheckCXXCompilerFlag)
-
-check_cxx_compiler_flag("-Wl,-flto" LTO_CAPABLE)
+include(CheckIPOSupported)
 
 add_library(${PROJECT_NAME}
     "src/logging.cpp"
@@ -17,11 +15,20 @@ add_library(${PROJECT_NAME}
     "${CMAKE_CURRENT_BINARY_DIR}/version.cpp"
     )
 
-set_target_properties(${PROJECT_NAME} PROPERTIES VERSION ${PROJECT_VERSION})
+set_target_properties(${PROJECT_NAME} PROPERTIES
+    SOVERSION 0
+    VERSION ${PROJECT_VERSION})
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
+
+check_ipo_supported(RESULT result OUTPUT output)
+if(result)
+    set_property(TARGET ${PROJECT_NAME} PROPERTY INTERPROCEDURAL_OPTIMIZATION TRUE)
+else()
+    message(WARNING "Link-time optimization (LTO) is not supported: ${output}")
+endif()
 
 find_package(CURL REQUIRED)
 if (CMAKE_VERSION VERSION_LESS 3.12)
@@ -36,6 +43,7 @@ target_compile_options(${PROJECT_NAME} PRIVATE
     "-fno-exceptions"
     "-fno-rtti"
     "-fvisibility=hidden"
+    "-fvisibility-inlines-hidden"
     "-Wall"
     "-Wextra"
     "-Werror"
@@ -64,11 +72,6 @@ else ()
     target_compile_definitions(${PROJECT_NAME} PRIVATE "AWS_LAMBDA_LOG=0")
 endif()
 
-if ((BUILD_SHARED_LIBS) AND (LTO_CAPABLE))
-    target_compile_options(${PROJECT_NAME} PRIVATE "-flto")
-    target_link_libraries(${PROJECT_NAME} PRIVATE "-flto")
-endif()
-
 #tests
 if (ENABLE_TESTS)
     enable_testing()
@@ -81,24 +84,37 @@ configure_file(
     "${CMAKE_CURRENT_BINARY_DIR}/version.cpp"
     NEWLINE_STYLE LF)
 
+include (CMakePackageConfigHelpers)
+
+write_basic_package_version_file("${PROJECT_NAME}-config-version.cmake"
+    VERSION ${PROJECT_VERSION}
+    COMPATIBILITY SameMajorVersion)
+
 # installation
 install(FILES "include/aws/http/response.h"
     DESTINATION "include/aws/http")
 
-install(FILES 
+install(FILES
     "include/aws/lambda-runtime/runtime.h"
     "include/aws/lambda-runtime/version.h"
     "include/aws/lambda-runtime/outcome.h"
-    DESTINATION "include/aws/lambda-runtime")
+    DESTINATION "include/aws/lambda-runtime"
+    COMPONENT ${PROJECT_NAME}-Development)
 
 install(FILES "include/aws/logging/logging.h"
     DESTINATION "include/aws/logging")
 
+include(GNUInstallDirs)
 install(TARGETS ${PROJECT_NAME}
     EXPORT ${PROJECT_NAME}-targets
-    ARCHIVE DESTINATION lib
-    LIBRARY DESTINATION lib
-    RUNTIME DESTINATION bin)
+    ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT ${PROJECT_NAME}-Development
+    LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR}
+    COMPONENT ${PROJECT_NAME}-Runtime
+    NAMELINK_COMPONENT ${PROJECT_NAME}-Developemnt
+    RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+    COMPONENT ${PROJECT_NAME}-Runtime
+    )
 
 configure_file("${CMAKE_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
@@ -111,6 +127,7 @@ install(EXPORT "${PROJECT_NAME}-targets"
     NAMESPACE AWS::)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
+    ${PROJECT_NAME}-config-version.cmake
     DESTINATION "lib/${PROJECT_NAME}/cmake/")
 
 install(PROGRAMS "${CMAKE_SOURCE_DIR}/packaging/packager"


### PR DESCRIPTION
- Set the SONAME on the library to generate correct symlinks
- Set visibility of **inline** functions to hidden [1]
- Use the built-in LTO detection mechanism instead of rolling my own (requires CMake 3.9)

[1] I didn't use `CMAKE_CXX_VISIBILITY_PRESET` and `CMAKE_VISIBILITY_INLINES_HIDDEN` because IMO they obscure the compiler flags and this library only builds/runs on linux (and Windows has visibility hidden by default anyways). Let me know if you disagree, I don't have strong opinions about this.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
