### PR TITLE
set CURLOPT_HTTPHEADER to include User-Agent

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -235,6 +235,7 @@ runtime::next_outcome runtime::get_next()
 
     curl_slist* headers = nullptr;
     headers = curl_slist_append(headers, get_user_agent_header().c_str());
+    curl_easy_setopt(m_curl_handle, CURLOPT_HTTPHEADER, headers);
 
     logging::log_debug(LOG_TAG, "Making request to %s", m_endpoints[Endpoints::NEXT].c_str());
     CURLcode curl_code = curl_easy_perform(m_curl_handle);


### PR DESCRIPTION
*Issue #, if available:*

N/A

*Description of changes:*

The User-Agent header was being constructed, but not being set with the request.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
