### PR TITLE
Bump minimum required CMake version in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,7 +33,7 @@ $ make && make install
 To consume this library in a project that is also using CMake, you would do:
 
 ```cmake
-cmake_minimum_required(VERSION 3.5)
+cmake_minimum_required(VERSION 3.9)
 set(CMAKE_CXX_STANDARD 11)
 project(demo LANGUAGES CXX)
 find_package(aws-lambda-runtime)


### PR DESCRIPTION
- Commit #a9e34da5 bumped the required CMake version in the
  CMakeLists.txt file, but not in the README

*Issue #, if available:*
- None

*Description of changes:*
- Bump minimum required CMake version in README

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
- Yes
