### PR TITLE
Set clang-tidy header filter

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -2,7 +2,7 @@
 Checks:
 'clang-diagnostic-*,clang-analyzer-*,performance-*,readability-*,modernize-*,bugprone-*,misc-*,-modernize-use-trailing-return-type'
 WarningsAsErrors: '*'
-HeaderFilterRegex: ''
+HeaderFilterRegex: 'include/aws/.*\.h$'
 FormatStyle: 'none'
 CheckOptions:
   - key:             modernize-pass-by-value.ValuesOnly


### PR DESCRIPTION
The filter tells clang-tidy which headers to scan in every TU it scans.
Errors and warnings in a TU are turned on by default. But the headers
included in the TU will only be scanned if they match the regex.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
