### PR TITLE
Update README.md to reflect newer CMake dependency 

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ Since AWS Lambda runs on GNU/Linux, you should build this runtime library and yo
 
 ### Prerequisites
 Make sure you have the following packages installed first:
-1. CMake (version 3.5 or later)
+1. CMake (version 3.9 or later)
 1. git
 1. Make or Ninja
 1. zip


### PR DESCRIPTION
Update README.md to reflect newer CMake dependency for in #68 

*Description of changes:*

Found while setting up an AL1 build. The minimum required CMake was raised in #68 

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
