### PR TITLE
packager: include only the 64-bit version of glibc

### DIFF
--- a/packaging/packager
+++ b/packaging/packager
@@ -73,8 +73,8 @@ function package_libc_via_dpkg() {
 
 function package_libc_via_rpm() {
     if type rpm > /dev/null 2>&1; then
-       if [[ $(rpm --query --list glibc | wc -l) -gt 1 ]]; then
-           rpm --query --list glibc | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+       if [[ $(rpm --query --list glibc.x86_64 | wc -l) -gt 1 ]]; then
+           rpm --query --list glibc.x86_64 | sed -E '/\.so$|\.so\.[0-9]+$/!d'
        fi
     fi
 }


### PR DESCRIPTION
This fixes #83.

On newer versions of Fedora the glibc rpm includes 32-bit and 64-bit versions of the shared objects (the *.so* files). Depending on the order of the `rpm` output the resulting `zip` with the lambda function is a mix of 32-bit and 64-bit files. This patch makes sure only the 64-bit version of the files are included in the archive.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
