### PR TITLE
CMakeLists.txt: use proper libdir

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -120,13 +120,13 @@ configure_file("${CMAKE_CURRENT_SOURCE_DIR}/cmake/${PROJECT_NAME}-config.cmake"
 export(EXPORT "${PROJECT_NAME}-targets" NAMESPACE AWS::)
 
 install(EXPORT "${PROJECT_NAME}-targets"
-    DESTINATION "lib/${PROJECT_NAME}/cmake/"
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake/"
     NAMESPACE AWS::)
 
 install(FILES "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config.cmake"
     "${CMAKE_CURRENT_BINARY_DIR}/${PROJECT_NAME}-config-version.cmake"
-    DESTINATION "lib/${PROJECT_NAME}/cmake/")
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake/")
 
 install(PROGRAMS "${CMAKE_CURRENT_SOURCE_DIR}/packaging/packager"
-    DESTINATION "lib/${PROJECT_NAME}/cmake/")
+    DESTINATION "${CMAKE_INSTALL_LIBDIR}/${PROJECT_NAME}/cmake/")
 


### PR DESCRIPTION
It turn's out that the 'lib' directory is hard-coded. Change this to use `CMAKE_INSTALL_LIBDIR`.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
