### PR TITLE
use platform auto-detection in backward.h

### DIFF
--- a/src/backward.h
+++ b/src/backward.h
@@ -43,7 +43,7 @@
 
 // You can define one of the following (or leave it to the auto-detection):
 //
-#    define BACKWARD_SYSTEM_LINUX
+//  #define BACKWARD_SYSTEM_LINUX
 //	- specialization for linux
 //
 // #define BACKWARD_SYSTEM_DARWIN


### PR DESCRIPTION
*Description of changes:*

```
<>/src/backward.h:188:22: fatal error: 'link.h' file not found
#            include <link.h>
                     ^~~~~~~~
```

I have a few projects that consume the library, but am unable to run their unit tests locally on my MacbBok because of the above error. Using auto-detection in backward.h resolves the issue.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
