### PR TITLE
Optimizations

### DIFF
--- a/include/aws/logging/logging.h
+++ b/include/aws/logging/logging.h
@@ -27,7 +27,7 @@ enum class verbosity {
 
 void log(verbosity v, char const* tag, char const* msg, va_list args);
 
-[[gnu::format(printf, 2, 3)]] static inline void log_error(char const* tag, char const* msg, ...)
+[[gnu::format(printf, 2, 3)]] inline void log_error(char const* tag, char const* msg, ...)
 {
     va_list args;
     va_start(args, msg);
@@ -37,7 +37,7 @@ void log(verbosity v, char const* tag, char const* msg, va_list args);
     (void)msg;
 }
 
-[[gnu::format(printf, 2, 3)]] static inline void log_info(char const* tag, char const* msg, ...)
+[[gnu::format(printf, 2, 3)]] inline void log_info(char const* tag, char const* msg, ...)
 {
 #if AWS_LAMBDA_LOG >= 1
     va_list args;
@@ -50,7 +50,7 @@ void log(verbosity v, char const* tag, char const* msg, va_list args);
 #endif
 }
 
-[[gnu::format(printf, 2, 3)]] static inline void log_debug(char const* tag, char const* msg, ...)
+[[gnu::format(printf, 2, 3)]] inline void log_debug(char const* tag, char const* msg, ...)
 {
 #if AWS_LAMBDA_LOG >= 2
     va_list args;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -412,7 +412,7 @@ void run_handler(std::function<invocation_response(invocation_request const&)> c
     size_t const max_retries = 3;
 
     while (retries < max_retries) {
-        const auto next_outcome = rt.get_next();
+        auto next_outcome = rt.get_next();
         if (!next_outcome.is_success()) {
             if (next_outcome.get_failure() == aws::http::response_code::REQUEST_NOT_MADE) {
                 ++retries;
@@ -429,7 +429,7 @@ void run_handler(std::function<invocation_response(invocation_request const&)> c
 
         retries = 0;
 
-        auto const& req = next_outcome.get_result();
+        auto const req = std::move(next_outcome).get_result();
         logging::log_info(LOG_TAG, "Invoking user handler");
         invocation_response res = handler(req);
         logging::log_info(LOG_TAG, "Invoking user handler completed.");


### PR DESCRIPTION
Avoid copying the result of the 'outcome' class.

Adding rvalue ref-qualifiers to the 'outcome' class getters enables
moving out the result instead of copying it. In this case, we can avoid
copying the request payload.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
