### PR TITLE
Change the version on master branch 0.0.0-dev suffix

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,7 +1,7 @@
 cmake_minimum_required(VERSION 3.9)
 set(CMAKE_CXX_STANDARD 11)
 project(aws-lambda-runtime
-    VERSION 0.2.6
+    VERSION 0.0.0
     LANGUAGES CXX)
 
 option(ENABLE_LTO "Enables link-time optimization, requires compiler support." ON)
@@ -16,7 +16,7 @@ add_library(${PROJECT_NAME}
 
 set_target_properties(${PROJECT_NAME} PROPERTIES
     SOVERSION 0
-    VERSION ${PROJECT_VERSION})
+    VERSION ${PROJECT_VERSION}-dev)
 
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>

--- a/tests/version_tests.cpp
+++ b/tests/version_tests.cpp
@@ -12,7 +12,7 @@ TEST(VersionTests, get_version_major)
 TEST(VersionTests, get_version_minor)
 {
     auto version = get_version_minor();
-    ASSERT_GE(version, 1);
+    ASSERT_GE(version, 0);
 }
 
 TEST(VersionTests, get_version_patch)


### PR DESCRIPTION
Releases will have that suffix removed.

As part of cutting a release process, we'll have to put the right version number.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
