### PR TITLE
Cast type explicitly for fix build error

### DIFF
--- a/src/backward.h
+++ b/src/backward.h
@@ -3262,7 +3262,7 @@ public:
         if (st.size() == 0) {
             return;
         }
-        _symbols.reset(backtrace_symbols(st.begin(), st.size()));
+        _symbols.reset(backtrace_symbols(st.begin(), (int)st.size()));
     }
 
     ResolvedTrace resolve(ResolvedTrace trace)


### PR DESCRIPTION
*Issue #, if available:*
Fix build error on `Apple clang version 12.0.0 (clang-1200.0.32.27)`

```
src/backward.h:3265:57: error: 
      implicit conversion loses integer precision: 'size_t'
      (aka 'unsigned long') to 'int' [-Werror,-Wshorten-64-to-32]
        _symbols.reset(backtrace_symbols(st.begin(), st.size()));
```

*Description of changes:*
Cast type explicitly

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
