### PR TITLE
packager: fetch glibc corresponding to the architecture

### DIFF
--- a/packaging/packager
+++ b/packaging/packager
@@ -45,6 +45,7 @@ done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 PKG_BIN_PATH=$1
+architecture=$(arch)
 
 if [ ! -f "$PKG_BIN_PATH" ]; then
     echo "$PKG_BIN_PATH" - No such file.;
@@ -73,8 +74,8 @@ function package_libc_via_dpkg() {
 
 function package_libc_via_rpm() {
     if type rpm > /dev/null 2>&1; then
-       if [[ $(rpm --query --list glibc.x86_64 | wc -l) -gt 1 ]]; then
-           rpm --query --list glibc.x86_64 | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+       if [[ $(rpm --query --list glibc.$architecture | wc -l) -gt 1 ]]; then
+           rpm --query --list glibc.$architecture | sed -E '/\.so$|\.so\.[0-9]+$/!d'
        fi
     fi
 }


### PR DESCRIPTION
*Description of changes:*
Package currently fails to build a cpp code on aarch64 platform.
Fixed failing build on aarch64 by dynamically fetching the $(arch) for glibc fetch. It was previously hardcoded to x86_64.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
