### PR TITLE
packager: fetch glibc corresponding to the host architecture on debian multiarch

### DIFF
--- a/packaging/packager
+++ b/packaging/packager
@@ -45,7 +45,6 @@ done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 PKG_BIN_PATH=$1
-architecture=$(arch)
 
 if [ ! -f "$PKG_BIN_PATH" ]; then
     echo "$PKG_BIN_PATH" - No such file.;
@@ -66,14 +65,16 @@ function package_libc_via_pacman {
 
 function package_libc_via_dpkg() {
     if type dpkg-query > /dev/null 2>&1; then
-        if [[ $(dpkg-query --listfiles libc6 | wc -l) -gt 0 ]]; then
-            dpkg-query --listfiles libc6 | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+       architecture=$(dpkg --print-architecture)
+        if [[ $(dpkg-query --listfiles libc6:$architecture | wc -l) -gt 0 ]]; then
+            dpkg-query --listfiles libc6:$architecture | sed -E '/\.so$|\.so\.[0-9]+$/!d'
         fi
     fi
 }
 
 function package_libc_via_rpm() {
     if type rpm > /dev/null 2>&1; then
+       architecture=$(arch)
        if [[ $(rpm --query --list glibc.$architecture | wc -l) -gt 1 ]]; then
            rpm --query --list glibc.$architecture | sed -E '/\.so$|\.so\.[0-9]+$/!d'
        fi


### PR DESCRIPTION
*Description of changes:*
This is a Debian version of PR #120. Many Debian machines have both amd64 and i386 (64 and 32 bit x86-64) installed. When "dpkg-query --listfiles libc6" is run, dpkg doesn't know which package it's referring to:
```
dpkg-query: error: --listfiles needs a valid package name but 'libc6' is not: ambiguous package name 'libc6' with more than one installed instance

Use --help for help about querying packages.
```

The main page for more information on MultiArch is https://wiki.debian.org/Multiarch .

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
