### PR TITLE
Fixes build on Alpine Linux

### DIFF
--- a/examples/Dockerfile
+++ b/examples/Dockerfile
@@ -1,3 +1,3 @@
 FROM alpine:latest
 
-RUN apk update && apk add cmake make git g++ bash curl-dev zlib-dev
+RUN apk add --no-cache cmake make g++ git bash curl-dev zlib-dev libexecinfo-dev

--- a/src/backward.h
+++ b/src/backward.h
@@ -240,6 +240,10 @@
 #        endif
 #    endif
 
+#    if BACKWARD_HAS_BACKTRACE_SYMBOL == 1
+#        include <dlfcn.h>
+#    endif
+
 #    if (BACKWARD_HAS_BACKTRACE == 1) || (BACKWARD_HAS_BACKTRACE_SYMBOL == 1)
 // then we shall rely on backtrace
 #        include <execinfo.h>
@@ -254,7 +258,7 @@
 // #define BACKWARD_HAS_UNWIND 1
 //  - unwind comes from libgcc, but I saw an equivalent inside clang itself.
 //  - with unwind, the stacktrace is as accurate as it can possibly be, since
-//  this is used by the C++ runtine in gcc/clang for stack unwinding on
+//  this is used by the C++ runtime in gcc/clang for stack unwinding on
 //  exception.
 //  - normally libgcc is already linked to your program by default.
 //


### PR DESCRIPTION
I would appreciate if someone could carefully look over this.

Alpine Linux needs the `libexecinfo-dev` package in order to have `execinfo.h` since glibc is no longer installed. The build process also was failing because `dlfcn.h` wasn't being included in `src/backward.h`.

Fixes #29 #124

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
