### PR TITLE
Packaging support on Alpine Linux

### DIFF
--- a/packaging/packager
+++ b/packaging/packager
@@ -61,9 +61,9 @@ function pluck_so_files() {
 }
 
 function package_libc_alpine() {
-    if grep -F "Alpine Linux" < /etc/os-release > /dev/null; then
+    if grep --fixed-strings "Alpine Linux" < /etc/os-release > /dev/null; then
         if type apk > /dev/null 2>&1; then
-            apk info -L musl 2>/dev/null | pluck_so_files | sed 's/^/\//'
+            apk info --contents musl 2>/dev/null | pluck_so_files | sed 's/^/\//'
         fi
     fi
 }

--- a/packaging/packager
+++ b/packaging/packager
@@ -45,7 +45,6 @@ done
 set -- "${POSITIONAL[@]}" # restore positional parameters
 
 PKG_BIN_PATH=$1
-architecture=$(arch)
 
 if [ ! -f "$PKG_BIN_PATH" ]; then
     echo "$PKG_BIN_PATH" - No such file.;
@@ -86,9 +85,11 @@ function package_libc_dpkg() {
 }
 
 function package_libc_rpm() {
+    arch=$(uname -m)
+
     if type rpm > /dev/null 2>&1; then
-       if [[ $(rpm --query --list glibc.$architecture | wc -l) -gt 1 ]]; then
-           rpm --query --list glibc.$architecture | pluck_so_files
+       if [[ $(rpm --query --list glibc.$arch | wc -l) -gt 1 ]]; then
+           rpm --query --list glibc.$arch | pluck_so_files
        fi
     fi
 }

--- a/packaging/packager
+++ b/packaging/packager
@@ -56,26 +56,39 @@ if ! type zip > /dev/null 2>&1; then
     echo "zip utility is not found. Please install it and re-run this script"
     exit 1
 fi
-function package_libc_via_pacman {
+
+function pluck_so_files() {
+    sed -E '/\.so$|\.so\.[0-9]+$/!d'
+}
+
+function package_libc_alpine() {
+    if grep -F "Alpine Linux" < /etc/os-release > /dev/null; then
+        if type apk > /dev/null 2>&1; then
+            apk info -L musl 2>/dev/null | pluck_so_files | sed 's/^/\//'
+        fi
+    fi
+}
+
+function package_libc_pacman() {
     if grep --extended-regexp "Arch Linux|Manjaro Linux" < /etc/os-release > /dev/null 2>&1; then
         if type pacman > /dev/null 2>&1; then
-            pacman --query --list --quiet glibc | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+            pacman --query --list --quiet glibc | pluck_so_files
         fi
     fi
 }
 
-function package_libc_via_dpkg() {
+function package_libc_dpkg() {
     if type dpkg-query > /dev/null 2>&1; then
         if [[ $(dpkg-query --listfiles libc6 | wc -l) -gt 0 ]]; then
-            dpkg-query --listfiles libc6 | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+            dpkg-query --listfiles libc6 | pluck_so_files
         fi
     fi
 }
 
-function package_libc_via_rpm() {
+function package_libc_rpm() {
     if type rpm > /dev/null 2>&1; then
        if [[ $(rpm --query --list glibc.$architecture | wc -l) -gt 1 ]]; then
-           rpm --query --list glibc.$architecture | sed -E '/\.so$|\.so\.[0-9]+$/!d'
+           rpm --query --list glibc.$architecture | pluck_so_files
        fi
     fi
 }
@@ -99,9 +112,10 @@ PKG_LD=""
 
 list=$(ldd "$PKG_BIN_PATH" | awk '{print $(NF-1)}')
 libc_libs=()
-libc_libs+=($(package_libc_via_dpkg))
-libc_libs+=($(package_libc_via_rpm))
-libc_libs+=($(package_libc_via_pacman))
+libc_libs+=($(package_libc_dpkg))
+libc_libs+=($(package_libc_rpm))
+libc_libs+=($(package_libc_pacman))
+libc_libs+=($(package_libc_alpine))
 
 mkdir -p "$PKG_DIR/bin" "$PKG_DIR/lib"
 


### PR DESCRIPTION
Added packaging support on Alpine Linux with the native [musl](https://musl.libc.org/) C library.

Building inside an Alpine Docker container looks like:
```
...
[100%] Built target experimental
  adding: bin/ (stored 0%)
  adding: bin/experimental (deflated 71%)
  adding: bootstrap (deflated 22%)
  adding: lib/ (stored 0%)
  adding: lib/ld-musl-x86_64.so.1 (deflated 37%)
  adding: lib/libcurl.so.4 (deflated 53%)
  adding: lib/libstdc++.so.6 (deflated 69%)
  adding: lib/libgcc_s.so.1 (deflated 56%)
  adding: lib/libnghttp2.so.14 (deflated 56%)
  adding: lib/libssl.so.1.1 (deflated 60%)
  adding: lib/libcrypto.so.1.1 (deflated 54%)
  adding: lib/libbrotlidec.so.1 (deflated 58%)
  adding: lib/libz.so.1 (deflated 50%)
  adding: lib/libbrotlicommon.so.1 (deflated 54%)
  adding: lib/libc.musl-x86_64.so.1 (stored 0%)
Created /opt/aws/lambda/experimental.zip
[100%] Built target aws-lambda-package-experimental
```

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
