### PR TITLE
Reduce string copying.

### DIFF
--- a/include/aws/lambda-runtime/outcome.h
+++ b/include/aws/lambda-runtime/outcome.h
@@ -61,6 +61,7 @@ public:
         else {
             new (&m_f) TFailure(std::move(other.m_f));
         }
+        m_success = other.m_success;
         return *this;
     }
 

--- a/include/aws/lambda-runtime/outcome.h
+++ b/include/aws/lambda-runtime/outcome.h
@@ -49,14 +49,19 @@ public:
         }
     }
 
-    ~outcome()
+    ~outcome() { destroy(); }
+
+    outcome& operator=(outcome&& other) noexcept
     {
-        if (m_success) {
-            m_s.~TResult();
+        assert(this != &other);
+        destroy();
+        if (other.m_success) {
+            new (&m_s) TResult(std::move(other.m_s));
         }
         else {
-            m_f.~TFailure();
+            new (&m_f) TFailure(std::move(other.m_f));
         }
+        return *this;
     }
 
     TResult const& get_result() const&
@@ -86,6 +91,16 @@ public:
     bool is_success() const { return m_success; }
 
 private:
+    void destroy()
+    {
+        if (m_success) {
+            m_s.~TResult();
+        }
+        else {
+            m_f.~TFailure();
+        }
+    }
+
     union {
         TResult m_s;
         TFailure m_f;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -116,9 +116,7 @@ static size_t write_header(char* ptr, size_t size, size_t nmemb, void* userdata)
         if (ptr[i] != ':') {
             continue;
         }
-        std::string key{ptr, i};
-        std::string value{ptr + i + 1, nmemb - i - 1};
-        resp->add_header(trim(key), trim(value));
+        resp->add_header(trim({ptr, i}), trim({ptr + i + 1, nmemb - i - 1}));
         break;
     }
     return size * nmemb;
@@ -160,9 +158,11 @@ static int rt_curl_debug_callback(CURL* handle, curl_infotype type, char* data, 
 runtime::runtime(std::string const& endpoint) : runtime(endpoint, "AWS_Lambda_Cpp/" + std::string(get_version())) {}
 
 runtime::runtime(std::string const& endpoint, std::string const& user_agent)
-    : m_user_agent_header("User-Agent: " + user_agent), m_endpoints{{endpoint + "/2018-06-01/runtime/init/error",
-                                                                     endpoint + "/2018-06-01/runtime/invocation/next",
-                                                                     endpoint + "/2018-06-01/runtime/invocation/"}},
+    : m_user_agent_header("User-Agent: " + user_agent),
+      m_endpoints{
+          {endpoint + "/2018-06-01/runtime/init/error",
+           endpoint + "/2018-06-01/runtime/invocation/next",
+           endpoint + "/2018-06-01/runtime/invocation/"}},
       m_curl_handle(curl_easy_init())
 {
     if (!m_curl_handle) {
@@ -264,32 +264,38 @@ runtime::next_outcome runtime::get_next()
         return resp.get_response_code();
     }
 
-    if (!resp.has_header(REQUEST_ID_HEADER)) {
+    auto out = resp.get_header(REQUEST_ID_HEADER);
+    if (!out.is_success()) {
         logging::log_error(LOG_TAG, "Failed to find header %s in response", REQUEST_ID_HEADER);
         return aws::http::response_code::REQUEST_NOT_MADE;
     }
     invocation_request req;
     req.payload = resp.get_body();
-    req.request_id = resp.get_header(REQUEST_ID_HEADER);
+    req.request_id = std::move(out).get_result();
 
-    if (resp.has_header(TRACE_ID_HEADER)) {
-        req.xray_trace_id = resp.get_header(TRACE_ID_HEADER);
+    out = resp.get_header(TRACE_ID_HEADER);
+    if (out.is_success()) {
+        req.xray_trace_id = std::move(out).get_result();
     }
 
-    if (resp.has_header(CLIENT_CONTEXT_HEADER)) {
-        req.client_context = resp.get_header(CLIENT_CONTEXT_HEADER);
+    out = resp.get_header(CLIENT_CONTEXT_HEADER);
+    if (out.is_success()) {
+        req.client_context = std::move(out).get_result();
     }
 
-    if (resp.has_header(COGNITO_IDENTITY_HEADER)) {
-        req.cognito_identity = resp.get_header(COGNITO_IDENTITY_HEADER);
+    out = resp.get_header(COGNITO_IDENTITY_HEADER);
+    if (out.is_success()) {
+        req.cognito_identity = std::move(out).get_result();
     }
 
-    if (resp.has_header(FUNCTION_ARN_HEADER)) {
-        req.function_arn = resp.get_header(FUNCTION_ARN_HEADER);
+    out = resp.get_header(FUNCTION_ARN_HEADER);
+    if (out.is_success()) {
+        req.function_arn = std::move(out).get_result();
     }
 
-    if (resp.has_header(DEADLINE_MS_HEADER)) {
-        auto const& deadline_string = resp.get_header(DEADLINE_MS_HEADER);
+    out = resp.get_header(DEADLINE_MS_HEADER);
+    if (out.is_success()) {
+        auto const& deadline_string = std::move(out).get_result();
         constexpr int base = 10;
         unsigned long ms = strtoul(deadline_string.c_str(), nullptr, base);
         assert(ms > 0);
@@ -301,7 +307,7 @@ runtime::next_outcome runtime::get_next()
             req.payload.c_str(),
             static_cast<int64_t>(req.get_time_remaining().count()));
     }
-    return next_outcome(req);
+    return {req};
 }
 
 runtime::post_outcome runtime::post_success(std::string const& request_id, invocation_response const& handler_response)


### PR DESCRIPTION
Optimized a few unnecessary string copies that should have been moves to
begin with. Additionally, I noticed that we're scanning the headers
twice once to test if a given header exists and another to get its
value, that is a perfect use case for std::optional, but since we need
to stay compatible with C++11 and C++14, we can use the 'outcome' class
instead.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
