### PR TITLE
Remove the need to have an S3 bucket to run the tests

### DIFF
--- a/ci/codebuild/amazonlinux-2017.03.yml
+++ b/ci/codebuild/amazonlinux-2017.03.yml
@@ -4,7 +4,6 @@ phases:
   pre_build:
     commands:
       - alias cmake=cmake3
-      - pip install awscli
       - ci/codebuild/build-cpp-sdk.sh
   build:
     commands:

--- a/ci/codebuild/run-tests.sh
+++ b/ci/codebuild/run-tests.sh
@@ -6,6 +6,5 @@ cd $CODEBUILD_SRC_DIR
 cd build
 rm -rf *.zip
 ninja $1
-aws s3 cp tests/resources/lambda-test-fun.zip s3://aws-lambda-cpp-tests/$2lambda-test-fun.zip
 ctest --output-on-failure
 

--- a/ci/codebuild/ubuntu-18.04.yml
+++ b/ci/codebuild/ubuntu-18.04.yml
@@ -3,7 +3,6 @@ version: 0.1
 phases:
   pre_build:
     commands:
-      - pip install awscli
       - ci/codebuild/build-cpp-sdk.sh
   build:
     commands:

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -86,10 +86,10 @@ struct LambdaRuntimeTest : public ::testing::Test {
         auto rc = stat(ZIP_FILE_PATH, &s);
         ASSERT_EQ(rc, 0) << std::string("file does not exist: ") + ZIP_FILE_PATH;
         Aws::Utils::CryptoBuffer zip_file_bytes(s.st_size);
-        auto *zip_file = fopen(ZIP_FILE_PATH, "r");
+        auto* zip_file = fopen(ZIP_FILE_PATH, "r");
         fread(zip_file_bytes.GetUnderlyingData(), sizeof(unsigned char), s.st_size, zip_file);
         fclose(zip_file);
-    
+
         Model::FunctionCode funcode;
         funcode.SetZipFile(zip_file_bytes);
         create_function_request.SetCode(funcode);

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -1,4 +1,5 @@
 #include <aws/core/client/ClientConfiguration.h>
+#include <aws/core/utils/Array.h>
 #include <aws/core/utils/Outcome.h>
 #include <aws/core/utils/memory/stl/AWSString.h>
 #include <aws/core/utils/memory/stl/AWSStringStream.h>
@@ -12,6 +13,8 @@
 #include <aws/lambda/model/DeleteFunctionRequest.h>
 #include <aws/lambda/model/InvokeRequest.h>
 #include "gtest/gtest.h"
+#include <cstdio>
+#include <sys/stat.h>
 #include <unistd.h>
 
 extern std::string aws_prefix;
@@ -20,8 +23,7 @@ namespace {
 
 using namespace Aws::Lambda;
 
-constexpr auto S3BUCKET = "aws-lambda-cpp-tests";
-constexpr auto S3KEY = "lambda-test-fun.zip";
+constexpr auto ZIP_FILE_PATH = "resources/lambda-test-fun.zip";
 constexpr auto REQUEST_TIMEOUT = 15 * 1000;
 
 struct LambdaRuntimeTest : public ::testing::Test {
@@ -79,8 +81,17 @@ struct LambdaRuntimeTest : public ::testing::Test {
         create_function_request.SetFunctionName(function_name);
         // I ran into eventual-consistency issues when creating the role dynamically as part of the test.
         create_function_request.SetRole(get_role_arn("integration-tests"));
+
+        struct stat s;
+        auto rc = stat(ZIP_FILE_PATH, &s);
+        ASSERT_EQ(rc, 0) << std::string("file does not exist: ") + ZIP_FILE_PATH;
+        Aws::Utils::CryptoBuffer zip_file_bytes(s.st_size);
+        auto *zip_file = fopen(ZIP_FILE_PATH, "r");
+        fread(zip_file_bytes.GetUnderlyingData(), sizeof(unsigned char), s.st_size, zip_file);
+        fclose(zip_file);
+    
         Model::FunctionCode funcode;
-        funcode.WithS3Bucket(S3BUCKET).WithS3Key(build_resource_name(S3KEY));
+        funcode.SetZipFile(zip_file_bytes);
         create_function_request.SetCode(funcode);
         create_function_request.SetRuntime(Aws::Lambda::Model::Runtime::provided);
 

--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -91,8 +91,8 @@ struct LambdaRuntimeTest : public ::testing::Test {
         fclose(zip_file);
 
         Model::FunctionCode funcode;
-        funcode.SetZipFile(zip_file_bytes);
-        create_function_request.SetCode(funcode);
+        funcode.SetZipFile(std::move(zip_file_bytes));
+        create_function_request.SetCode(std::move(funcode));
         create_function_request.SetRuntime(Aws::Lambda::Model::Runtime::provided);
 
         auto outcome = m_lambda_client.CreateFunction(create_function_request);


### PR DESCRIPTION
*Description of changes:*

I wanted to make it easier for other contributors to the the test cases. Right now, anyone who isn't working at Amazon would need to create their own bucket and edit the test case to point at it. 

S3 is nice for bypassing Lambda's direct zip upload limits, but I think these test produce zip files well under that limit 


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
