### PR TITLE
Fix issue raised in #140

### DIFF
--- a/ci/codebuild/format-check.sh
+++ b/ci/codebuild/format-check.sh
@@ -4,7 +4,7 @@ set -euo pipefail
 
 CLANG_FORMAT=clang-format
 
-if NOT type $CLANG_FORMAT > /dev/null 2>&1; then
+if ! type $CLANG_FORMAT > /dev/null 2>&1; then
     echo "No appropriate clang-format found."
     exit 1
 fi


### PR DESCRIPTION
Issue #140 

This change corrects the non-existent `NOT` alias/command pointed out by Ilya Sher.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
