### PR TITLE
Updated CMake commands to reflect that ENABLE_UNITY_BUILDS now defaults to ON in the AWS SDK

### DIFF
--- a/ci/codebuild/build-cpp-sdk.sh
+++ b/ci/codebuild/build-cpp-sdk.sh
@@ -8,7 +8,6 @@ mkdir build
 cd build
 cmake .. -GNinja -DBUILD_ONLY="lambda" \
     -DCMAKE_BUILD_TYPE=Release \
-    -DENABLE_UNITY_BUILD=ON \
     -DBUILD_SHARED_LIBS=ON \
     -DENABLE_TESTING=OFF \
     -DCMAKE_INSTALL_PREFIX=/install $@

--- a/examples/api-gateway/README.md
+++ b/examples/api-gateway/README.md
@@ -15,8 +15,7 @@ $ cmake .. -DBUILD_ONLY="core" \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=OFF \
   -DCUSTOM_MEMORY_MANAGEMENT=OFF \
-  -DCMAKE_INSTALL_PREFIX=~/install \
-  -DENABLE_UNITY_BUILD=ON
+  -DCMAKE_INSTALL_PREFIX=~/install
 $ make
 $ make install
 ```

--- a/examples/dynamodb/README.md
+++ b/examples/dynamodb/README.md
@@ -17,8 +17,7 @@ $ cmake .. -DBUILD_ONLY="dynamodb" \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=OFF \
   -DCUSTOM_MEMORY_MANAGEMENT=OFF \
-  -DCMAKE_INSTALL_PREFIX=~/install \
-  -DENABLE_UNITY_BUILD=ON
+  -DCMAKE_INSTALL_PREFIX=~/install
 
 $ make -j 4
 $ make install

--- a/examples/s3/README.md
+++ b/examples/s3/README.md
@@ -17,8 +17,7 @@ $ cmake .. -DBUILD_ONLY="s3" \
   -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=OFF \
   -DCUSTOM_MEMORY_MANAGEMENT=OFF \
-  -DCMAKE_INSTALL_PREFIX=~/install \
-  -DENABLE_UNITY_BUILD=ON
+  -DCMAKE_INSTALL_PREFIX=~/install
 
 $ make
 $ make install
@@ -34,7 +33,7 @@ $ mkdir build
 $ cd build
 $ cmake .. -DCMAKE_BUILD_TYPE=Release \
   -DBUILD_SHARED_LIBS=OFF \
-  -DCMAKE_INSTALL_PREFIX=~/install \
+  -DCMAKE_INSTALL_PREFIX=~/install
 $ make
 $ make install
 ```


### PR DESCRIPTION
This pull request makes a few changes to the READMEs. In particular:

- In the AWS C++ SDK  `ENABLE_UNITY_BUILD` defaults to `ON` since https://github.com/aws/aws-sdk-cpp/commit/2d17946f02b4fb7acd242759ca3bfc88102cb137
- The AWS Lambda C++ Runtime [doesn't have](https://github.com/awslabs/aws-lambda-cpp/blob/095ff84911d0f3dcd0f428c4a5b49124ee66ee6b/CMakeLists.txt#L7) a  `BUILD_SHARED_LIBS`  build option

- - -

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
