### PR TITLE
improving error log for runtime::get_next() curl failure

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -240,7 +240,10 @@ runtime::next_outcome runtime::get_next()
 
     if (curl_code != CURLE_OK) {
         logging::log_debug(LOG_TAG, "CURL returned error code %d - %s", curl_code, curl_easy_strerror(curl_code));
-        logging::log_error(LOG_TAG, "Failed to get next invocation. No Response from endpoint");
+        logging::log_error(
+            LOG_TAG,
+            "Failed to get next invocation. No Response from endpoint \"%s\"",
+            m_endpoints[Endpoints::NEXT].c_str());
         return aws::http::response_code::REQUEST_NOT_MADE;
     }
 


### PR DESCRIPTION
*Related to issue #26*

*Description of changes:*
Improves the error log when runtime::get_next() fails (curl error code and error message were only visible as debug logs. This PR promotes them to the error level in order to give users more clue about what is going wrong)

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
