### PR TITLE
tests: throw if AWS_REGION environment variable is missing

### DIFF
--- a/tests/runtime_tests.cpp
+++ b/tests/runtime_tests.cpp
@@ -44,6 +44,9 @@ struct LambdaRuntimeTest : public ::testing::Test {
         Aws::Client::ClientConfiguration config;
         config.requestTimeoutMs = REQUEST_TIMEOUT;
         config.region = Aws::Environment::GetEnv("AWS_REGION");
+        if (config.region.empty()) {
+            throw std::invalid_argument("environment variable AWS_REGION not set");
+        }
         return config;
     }
 


### PR DESCRIPTION

*Description of changes:*

I spent way too long trying to figure out why the tests were hanging for minutes doing retries on my bare linux installation, but worked fine when run on AWS Code Build. Hopefully this helps my future self and other contributors.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
