### PR TITLE
Add AWS CodeBuild workflow and Dockerfile for ArchLinux

### DIFF
--- a/ci/codebuild/arch-linux.yml
+++ b/ci/codebuild/arch-linux.yml
@@ -1,0 +1,9 @@
+version: 0.2
+# This uses the docker image specified in ci/docker/arch-linux
+phases:
+  build:
+    commands:
+      - echo Build started on `date`
+      - ./ci/codebuild/build.sh -DTEST_RESOURCE_PREFIX=lambda-cpp-archbtw
+      - ./ci/codebuild/run-tests.sh aws-lambda-package-lambda-test-fun
+      - echo Build completed on `date`

--- a/ci/docker/arch-linux
+++ b/ci/docker/arch-linux
@@ -1,0 +1,17 @@
+FROM public.ecr.aws/docker/library/archlinux:latest 
+
+RUN pacman -Sy --noconfirm git 
+RUN git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git
+RUN pacman -Sy --noconfirm \
+    cmake \
+    ninja \
+    clang \
+    curl \
+    zip
+
+RUN CC=/usr/bin/clang CXX=/usr/bin/clang++ cmake -Saws-sdk-cpp -Baws-sdk-cpp/build -GNinja \
+    -DBUILD_ONLY=lambda \
+    -DUSE_OPENSSL=OFF \ 
+    -DENABLE_TESTING=OFF
+RUN cmake --build aws-sdk-cpp/build -t install
+


### PR DESCRIPTION
*Description of changes:*

This change was originally a part of #159 

Adds CI support for ArchLinux `ci/docker/arch-linux` `ci/codebuild/arch-linux.yml`

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
