### PR TITLE
Re-write codebuild.yml and dockerfiles for consistency and code build execution speed

### DIFF
--- a/ci/codebuild/alpine-3.15.yml
+++ b/ci/codebuild/alpine-3.15.yml
@@ -1,16 +1,9 @@
 version: 0.2
 # This uses the docker image specified in ci/docker/alpine-linux-3.15
 phases:
-  pre_build:
-    commands:
-      - pip install awscli
-      - ci/codebuild/build-cpp-sdk.sh
   build:
     commands:
       - echo Build started on `date`
-      - ci/codebuild/build.sh -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_TESTS=ON -DTEST_RESOURCE_PREFIX=alpine315
-      - ci/codebuild/run-tests.sh  aws-lambda-package-lambda-test-fun alpine315
-  post_build:
-    commands:
+      - ./ci/codebuild/build.sh -DTEST_RESOURCE_PREFIX=lambda-cpp-alpine315
+      - ./ci/codebuild/run-tests.sh aws-lambda-package-lambda-test-fun
       - echo Build completed on `date`
-

--- a/ci/codebuild/amazonlinux-2.yml
+++ b/ci/codebuild/amazonlinux-2.yml
@@ -1,12 +1,10 @@
 version: 0.2
 phases:
-  pre_build:
-    commands:
-      - yum install -y zip
   build:
     commands:
-      - cmake3 -S . -B build -DENABLE_TESTS=ON -DTEST_RESOURCE_PREFIX=al2arm -GNinja
-      - cd build
-      - ninja-build
-      - ninja-build aws-lambda-package-lambda-test-fun
-      - ctest3 --output-on-failure
+      - env
+      - echo Build started on `date`
+      - ./ci/codebuild/build.sh -DTEST_RESOURCE_PREFIX=lambda-cpp-al2_$(arch)
+      - ./ci/codebuild/run-tests.sh aws-lambda-package-lambda-test-fun
+      - ./ci/codebuild/run-tests.sh aws-lambda-package-lambda-test-fun-no-glibc
+      - echo Build completed on `date`

--- a/ci/codebuild/amazonlinux-2017.03.yml
+++ b/ci/codebuild/amazonlinux-2017.03.yml
@@ -1,17 +1,12 @@
-version: 0.1
+version: 0.2
 # This uses the docker image specified in ci/docker/amazon-linux-2017.03
 phases:
-  pre_build:
-    commands:
-      - alias cmake=cmake3
-      - ci/codebuild/build-cpp-sdk.sh
   build:
     commands:
       - echo Build started on `date`
-      - ci/codebuild/build.sh -DENABLE_TESTS=ON -DTEST_RESOURCE_PREFIX=amzn201703
-      - ci/codebuild/run-tests.sh  aws-lambda-package-lambda-test-fun amzn201703
-      - ci/codebuild/run-tests.sh  aws-lambda-package-lambda-test-fun-no-glibc amzn201703
-  post_build:
-    commands:
+      - yum install -y binutils
+      - ./ci/codebuild/build.sh -DTEST_RESOURCE_PREFIX=lambda-cpp-amzn201703
+      - ./ci/codebuild/run-tests.sh aws-lambda-package-lambda-test-fun
+      - ./ci/codebuild/run-tests.sh aws-lambda-package-lambda-test-fun-no-glibc
       - echo Build completed on `date`
 

--- a/ci/codebuild/build.sh
+++ b/ci/codebuild/build.sh
@@ -6,6 +6,10 @@ set -euo pipefail
 cd $CODEBUILD_SRC_DIR
 mkdir build
 cd build
-cmake .. -GNinja -DBUILD_SHARED_LIBS=ON -DCMAKE_BUILD_TYPE=Debug -DCMAKE_INSTALL_PREFIX=/install $@
+cmake .. -GNinja \
+  -DBUILD_SHARED_LIBS=ON \
+  -DCMAKE_BUILD_TYPE=Debug \
+  -DENABLE_TESTS=ON \
+  -DCMAKE_INSTALL_PREFIX=/install $@
 ninja
 ninja install

--- a/ci/codebuild/ubuntu-18.04.yml
+++ b/ci/codebuild/ubuntu-18.04.yml
@@ -1,15 +1,9 @@
-version: 0.1
+version: 0.2
 # This uses the docker image specified in ci/docker/ubuntu-linux-18.04
 phases:
-  pre_build:
-    commands:
-      - ci/codebuild/build-cpp-sdk.sh
   build:
     commands:
       - echo Build started on `date`
-      - ci/codebuild/build.sh -DCMAKE_EXPORT_COMPILE_COMMANDS=ON -DENABLE_TESTS=ON -DTEST_RESOURCE_PREFIX=ubuntu1804
-      - ci/codebuild/run-tests.sh  aws-lambda-package-lambda-test-fun ubuntu1804
-  post_build:
-    commands:
+      - ./ci/codebuild/build.sh -DTEST_RESOURCE_PREFIX=lambda-cpp-ubuntu1804
+      - ./ci/codebuild/run-tests.sh aws-lambda-package-lambda-test-fun
       - echo Build completed on `date`
-

--- a/ci/docker/alpine-linux-3.15
+++ b/ci/docker/alpine-linux-3.15
@@ -1,5 +1,19 @@
-FROM alpine:3.15
+FROM public.ecr.aws/docker/library/alpine:3.15
 
-RUN apk add --no-cache g++ cmake git bash py3-pip libexecinfo-dev ninja curl-dev zlib-dev zip
+RUN apk add --no-cache \
+    bash \
+    cmake \
+    curl-dev \
+    g++ \
+    git \
+    libexecinfo-dev \
+    ninja \
+    openssl-libs-static \
+    zlib-dev \
+    zip
 
 RUN git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp.git
+RUN cmake -Saws-sdk-cpp -Baws-sdk-cpp/build -GNinja \
+    -DBUILD_ONLY=lambda \
+    -DENABLE_TESTING=OFF
+RUN cd aws-sdk-cpp/build && ninja && ninja install

--- a/ci/docker/amazon-linux-2
+++ b/ci/docker/amazon-linux-2
@@ -1,6 +1,16 @@
 FROM public.ecr.aws/amazonlinux/amazonlinux:2
-RUN yum install -y cmake3 ninja-build git gcc-c++ openssl-devel curl-devel
+RUN yum install -y \
+    cmake3 \
+    ninja-build \
+    git \
+    gcc-c++ \
+    openssl-devel \
+    curl-devel \
+    openssl-static \
+    zip
 RUN git clone https://github.com/aws/aws-sdk-cpp --recurse-submodules
 RUN cmake3 -Saws-sdk-cpp -Baws-sdk-cpp/build -DBUILD_ONLY=lambda -DENABLE_TESTING=OFF -GNinja
 RUN cd aws-sdk-cpp/build && ninja-build && ninja-build install
-RUN yum install -y openssl-static
+RUN ln -s /usr/bin/cmake3 /usr/local/bin/cmake
+RUN ln -s /usr/bin/ctest3 /usr/local/bin/ctest
+RUN ln -s /usr/bin/ninja-build /usr/local/bin/ninja

--- a/ci/docker/amazon-linux-2017.03
+++ b/ci/docker/amazon-linux-2017.03
@@ -1,10 +1,18 @@
-FROM amazonlinux:2017.03
+FROM public.ecr.aws/amazonlinux/amazonlinux:2018.03
 
-RUN yum install gcc64-c++ git ninja-build curl-devel openssl-devel zlib-devel gtest-devel python36-pip zip -y
+RUN yum install -y \
+    gcc-c++ \
+    git \
+    ninja-build \
+    curl-devel \
+    openssl-devel \
+    openssl-static \
+    zlib-devel \
+    gtest-devel \
+    zip
+RUN curl -fLo cmake-install https://github.com/Kitware/CMake/releases/download/v3.13.0/cmake-3.13.0-Linux-x86_64.sh && \
+    sh cmake-install --skip-license --prefix=/usr --exclude-subdirectory;
 RUN git clone --recurse-submodules https://github.com/aws/aws-sdk-cpp
-
-RUN curl -fLo cmake-install https://github.com/Kitware/CMake/releases/download/v3.13.0/cmake-3.13.0-Linux-x86_64.sh; \
-sh cmake-install --skip-license --prefix=/usr --exclude-subdirectory;
-
-RUN pip-3.6 install --upgrade pip
-
+RUN cmake -Saws-sdk-cpp -Baws-sdk-cpp/build -DBUILD_ONLY=lambda -DENABLE_TESTING=OFF -GNinja
+RUN cd aws-sdk-cpp/build && ninja-build && ninja-build install
+RUN ln -s /usr/bin/ninja-build /usr/local/bin/ninja

--- a/ci/docker/ubuntu-linux-18.04
+++ b/ci/docker/ubuntu-linux-18.04
@@ -1,15 +1,22 @@
-FROM ubuntu:18.04
+FROM public.ecr.aws/ubuntu/ubuntu:18.04 
 
-RUN apt-get update; apt-get install git clang clang-tidy clang-format zlib1g-dev libssl-dev libcurl4-openssl-dev wget \
-ninja-build python3-pip zip -y
+RUN apt-get update
+RUN apt-get install -y \
+    git \
+    clang \
+    zlib1g-dev \
+    libssl-dev \
+    libcurl4-openssl-dev \
+    wget \
+    ninja-build \
+    zip
 
-
-RUN wget -O cmake-install https://github.com/Kitware/CMake/releases/download/v3.13.0/cmake-3.13.0-Linux-x86_64.sh; \
-sh cmake-install --skip-license --prefix=/usr --exclude-subdirectory;
-
-RUN pip3 install --upgrade pip
-
-RUN git clone https://github.com/aws/aws-sdk-cpp.git --recurse-submodules
+RUN wget -O cmake-install https://github.com/Kitware/CMake/releases/download/v3.13.0/cmake-3.13.0-Linux-x86_64.sh && \
+    sh cmake-install --skip-license --prefix=/usr --exclude-subdirectory;
 
 RUN update-alternatives --set cc /usr/bin/clang
 RUN update-alternatives --set c++ /usr/bin/clang++
+
+RUN git clone https://github.com/aws/aws-sdk-cpp.git --recurse-submodules
+RUN cmake -Saws-sdk-cpp -Baws-sdk-cpp/build -DBUILD_ONLY=lambda -DENABLE_TESTING=OFF -GNinja
+RUN cd aws-sdk-cpp/build && ninja && ninja install


### PR DESCRIPTION
*Description of changes:*

This change was original posted as a part of #159 

Mostly did this to resolve constantly waiting for AWS SDK build, by moving the step out of any `ci/codebuild/*.yml` and into the respective `ci/docker/*` - to cache it for personal sanity.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
