### PR TITLE
Make LTO opt-in by default instead of opt-out

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -4,7 +4,7 @@ project(aws-lambda-runtime
     VERSION 0.0.0
     LANGUAGES CXX)
 
-option(ENABLE_LTO "Enables link-time optimization, requires compiler support." ON)
+option(ENABLE_LTO "Enables link-time optimization, requires compiler support." OFF)
 option(ENABLE_TESTS "Enables building the test project, requires AWS C++ SDK." OFF)
 
 add_library(${PROJECT_NAME}


### PR DESCRIPTION
LTO has caused problems to a few users (see issues linked at the bottom).
The problem is the runtime is built as a static library by default unless otherwise specified via CMake flags, and also LTO is enabled by default. Those two things combined means the user must turn on LTO when they build their application if they're using GCC.

Since we don't have evidence that LTO is making a substantial difference in the runtime, it seems prudent to leave the option but turn if off by default.

Issues where this has been reported:
https://github.com/awslabs/aws-lambda-cpp/issues/151 
https://github.com/awslabs/aws-lambda-cpp/issues/128

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
