### PR TITLE
Add GitHub code scanner workflow

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -29,6 +29,11 @@ jobs:
     - name: Checkout repository
       uses: actions/checkout@v3
 
+    # Install libcurl dependency
+    - name: Install dependencies
+      run: sudo apt install -y libcurl4-openssl-dev
+
+
     # Initializes the CodeQL tools for scanning.
     - name: Initialize CodeQL
       uses: github/codeql-action/init@v2
@@ -44,7 +49,7 @@ jobs:
 
     - run: |
        echo "Run, CMake build script"
-       cmake -B ${{github.workspace}}/build  -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF
+       cmake -B ${{github.workspace}}/build -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF
 
     - name: Perform CodeQL Analysis
       uses: github/codeql-action/analyze@v2

--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -1,0 +1,53 @@
+name: "Code Quality"
+
+on:
+  push:
+    branches: [ "master" ]
+  pull_request:
+    # The branches below must be a subset of the branches above
+    branches: [ "master" ]
+  schedule:
+    - cron: '32 14 * * 2'
+
+jobs:
+  analyze:
+    name: Analyze
+    runs-on: ubuntu-latest
+    permissions:
+      actions: read
+      contents: read
+      security-events: write
+
+    strategy:
+      fail-fast: false
+      matrix:
+        language: [ 'cpp' ]
+        # CodeQL supports [ 'cpp', 'csharp', 'go', 'java', 'javascript', 'python', 'ruby' ]
+        # Learn more about CodeQL language support at https://aka.ms/codeql-docs/language-support
+
+    steps:
+    - name: Checkout repository
+      uses: actions/checkout@v3
+
+    # Initializes the CodeQL tools for scanning.
+    - name: Initialize CodeQL
+      uses: github/codeql-action/init@v2
+      with:
+        languages: ${{ matrix.language }}
+        # If you wish to specify custom queries, you can do so here or in a config file.
+        # By default, queries listed here will override any specified in a config file.
+        # Prefix the list here with "+" to use these queries and those in the config file.
+
+        # Details on CodeQL's query packs refer to : https://docs.github.com/en/code-security/code-scanning/automatically-scanning-your-code-for-vulnerabilities-and-errors/configuring-code-scanning#using-queries-in-ql-packs
+        # queries: security-extended,security-and-quality
+
+
+    - run: |
+       echo "Run, CMake build script"
+       cmake -B ${{github.workspace}}/build  -DBUILD_SHARED_LIBS=ON -DBUILD_TESTING=OFF
+
+    - name: Perform CodeQL Analysis
+      uses: github/codeql-action/analyze@v2
+      with:
+        category: "/language:${{matrix.language}}"
+

--- a/README.md
+++ b/README.md
@@ -1,5 +1,6 @@
 [![GitHub](https://img.shields.io/github/license/awslabs/aws-lambda-cpp.svg)](https://github.com/awslabs/aws-lambda-cpp/blob/master/LICENSE)
-[![Language grade: C/C++](https://img.shields.io/lgtm/grade/cpp/g/awslabs/aws-lambda-cpp.svg?logo=lgtm&logoWidth=18)](https://lgtm.com/projects/g/awslabs/aws-lambda-cpp/context:cpp)
+
+![Code Quality badge](https://github.com/awslabs/aws-lambda-cpp/actions/workflows/code-quality.yml/badge.svg)
 
 | OS | Arch | Status |
 |----|------|--------|

--- a/README.md
+++ b/README.md
@@ -1,5 +1,4 @@
 [![GitHub](https://img.shields.io/github/license/awslabs/aws-lambda-cpp.svg)](https://github.com/awslabs/aws-lambda-cpp/blob/master/LICENSE)
-
 ![Code Quality badge](https://github.com/awslabs/aws-lambda-cpp/actions/workflows/code-quality.yml/badge.svg)
 
 | OS | Arch | Status |


### PR DESCRIPTION
[lgtm.com](https://lgtm.com) is shutting down in December 2022.
It has been [replaced](https://github.blog/2022-08-15-the-next-step-for-lgtm-com-github-code-scanning/) with GitHub code scanner.
This PR adds the workflow for GitHub actions and updates the README with the updated badge.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
