### PR TITLE
Pass payload by value to enable moving arguments

### DIFF
--- a/examples/dynamodb/main.cpp
+++ b/examples/dynamodb/main.cpp
@@ -173,9 +173,9 @@ aws::lambda_runtime::invocation_response my_handler(
     if (cr.error_msg) {
         JsonValue response;
         response.WithString("body", cr.error_msg).WithInteger("statusCode", 400);
-        auto const apig_response = response.View().WriteCompact();
+        auto apig_response = response.View().WriteCompact();
         AWS_LOGSTREAM_ERROR(TAG, "Validation failed. " << apig_response);
-        return aws::lambda_runtime::invocation_response::success(apig_response, "application/json");
+        return aws::lambda_runtime::invocation_response::success(std::move(apig_response), "application/json");
     }
 
     auto result = query(cr, client);
@@ -190,10 +190,10 @@ aws::lambda_runtime::invocation_response my_handler(
         response.WithString("body", "No data found for this product.").WithInteger("statusCode", 400);
     }
 
-    auto const apig_response = response.View().WriteCompact();
+    auto apig_response = response.View().WriteCompact();
     AWS_LOGSTREAM_DEBUG(TAG, "api gateway response: " << apig_response);
 
-    return aws::lambda_runtime::invocation_response::success(apig_response, "application/json");
+    return aws::lambda_runtime::invocation_response::success(std::move(apig_response), "application/json");
 }
 
 std::function<std::shared_ptr<Aws::Utils::Logging::LogSystemInterface>()> GetConsoleLoggerFactory()

--- a/examples/s3/main.cpp
+++ b/examples/s3/main.cpp
@@ -50,7 +50,7 @@ static invocation_response my_handler(invocation_request const& req, Aws::S3::S3
         return invocation_response::failure(err, "DownloadFailure");
     }
 
-    return invocation_response::success(base64_encoded_file, "application/base64");
+    return invocation_response::success(std::move(base64_encoded_file), "application/base64");
 }
 
 std::function<std::shared_ptr<Aws::Utils::Logging::LogSystemInterface>()> GetConsoleLoggerFactory()

--- a/include/aws/lambda-runtime/runtime.h
+++ b/include/aws/lambda-runtime/runtime.h
@@ -105,7 +105,7 @@ public:
     /**
      * Create a successful invocation response with the given payload and content-type.
      */
-    static invocation_response success(std::string const& payload, std::string const& content_type);
+    static invocation_response success(std::string payload, std::string content_type);
 
     /**
      * Create a failure response with the given error message and error type.

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -506,12 +506,12 @@ static std::string json_escape(std::string const& in)
 }
 
 AWS_LAMBDA_RUNTIME_API
-invocation_response invocation_response::success(std::string const& payload, std::string const& content_type)
+invocation_response invocation_response::success(std::string payload, std::string content_type)
 {
     invocation_response r;
     r.m_success = true;
-    r.m_content_type = content_type;
-    r.m_payload = payload;
+    r.m_content_type = std::move(content_type);
+    r.m_payload = std::move(payload);
     return r;
 }
 

--- a/tests/resources/lambda_function.cpp
+++ b/tests/resources/lambda_function.cpp
@@ -23,8 +23,8 @@ invocation_response echo_failure(invocation_request const& /*request*/)
 
 invocation_response binary_response(invocation_request const& /*request*/)
 {
-    const std::string png((char*)awslogo_png, AWSLOGO_PNG_LEN);
-    return invocation_response::success(png, "image/png");
+    std::string png((char*)awslogo_png, AWSLOGO_PNG_LEN);
+    return invocation_response::success(std::move(png), "image/png");
 }
 
 invocation_response crash_backtrace(invocation_request const& /*request*/)


### PR DESCRIPTION
Response payloads can be quite large. This change allows users to avoid copying the payload by doing:

```cpp
invocation_response::success(std::move(m_payload), ..);
```
The change is backwards compatible, and has no negative effect on users passing argument with the old style.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
