### PR TITLE
Build with ASan and UBSan

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -6,6 +6,7 @@ project(aws-lambda-runtime
 
 option(ENABLE_LTO "Enables link-time optimization, requires compiler support." OFF)
 option(ENABLE_TESTS "Enables building the test project, requires AWS C++ SDK." OFF)
+option(ENABLE_SANITIZERS "Enables ASan and UBSan." OFF)
 
 add_library(${PROJECT_NAME}
     "src/logging.cpp"
@@ -21,6 +22,11 @@ set_target_properties(${PROJECT_NAME} PROPERTIES
 target_include_directories(${PROJECT_NAME} PUBLIC
     $<BUILD_INTERFACE:${CMAKE_CURRENT_SOURCE_DIR}/include>
     $<INSTALL_INTERFACE:include>)
+
+if (ENABLE_SANITIZERS)
+    target_compile_options(${PROJECT_NAME} PUBLIC "-fsanitize=address,undefined")
+    target_link_libraries(${PROJECT_NAME} PUBLIC "-fsanitize=address,undefined")
+endif()
 
 if (ENABLE_LTO)
     include(CheckIPOSupported)

--- a/ci/codebuild/arch-linux.yml
+++ b/ci/codebuild/arch-linux.yml
@@ -4,6 +4,6 @@ phases:
   build:
     commands:
       - echo Build started on `date`
-      - ./ci/codebuild/build.sh -DTEST_RESOURCE_PREFIX=lambda-cpp-archbtw
+      - ./ci/codebuild/build.sh -DTEST_RESOURCE_PREFIX=lambda-cpp-archbtw -DENABLE_SANITIZERS=ON
       - ./ci/codebuild/run-tests.sh aws-lambda-package-lambda-test-fun
       - echo Build completed on `date`


### PR DESCRIPTION
Add an option to build with Address and Undefined-behavior sanitizers. And enable the option in one of the CI jobs.
For now Arch-linux seems to have the newest compiler compared with the other CI jobs, so I enabled it there.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
