### PR TITLE
Run apt-get update in code quality CI

### DIFF
--- a/.github/workflows/code-quality.yml
+++ b/.github/workflows/code-quality.yml
@@ -31,7 +31,7 @@ jobs:
 
     # Install libcurl dependency
     - name: Install dependencies
-      run: sudo apt install -y libcurl4-openssl-dev
+      run: sudo apt-get update && sudo apt install -y libcurl4-openssl-dev
 
 
     # Initializes the CodeQL tools for scanning.


### PR DESCRIPTION
Run apt-get update in code quality CI because otherwise it fails randomly.


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
