### PR TITLE
Fix clang-tidy benign warnings

### DIFF
--- a/.clang-tidy
+++ b/.clang-tidy
@@ -1,6 +1,7 @@
 ---
 Checks:
-'clang-diagnostic-*,clang-analyzer-*,performance-*,readability-*,modernize-*,bugprone-*,misc-*,-modernize-use-trailing-return-type'
+'clang-diagnostic-*,clang-analyzer-*,performance-*,readability-*,modernize-*,bugprone-*,misc-*,
+-modernize-use-trailing-return-type,-bugprone-easily-swappable-parameters,-readability-identifier-length'
 WarningsAsErrors: '*'
 HeaderFilterRegex: 'include/aws/.*\.h$'
 FormatStyle: 'none'

--- a/ci/codebuild/format-check.sh
+++ b/ci/codebuild/format-check.sh
@@ -13,6 +13,11 @@ FAIL=0
 SOURCE_FILES=$(find src include tests -type f -name "*.h" -o -name "*.cpp")
 for i in $SOURCE_FILES
 do
+    if [[ "$i" == *"gtest.h" || "$i" == *"backward.h" ]]; then
+        continue
+    fi
+
+    echo "$i\n"
     if [ $($CLANG_FORMAT -output-replacements-xml $i | grep -c "<replacement ") -ne 0 ]
     then
         echo "$i failed clang-format check."

--- a/include/aws/lambda-runtime/runtime.h
+++ b/include/aws/lambda-runtime/runtime.h
@@ -129,8 +129,7 @@ public:
     bool is_success() const { return m_success; }
 };
 
-struct no_result {
-};
+struct no_result {};
 
 class runtime {
 public:

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -25,6 +25,7 @@
 #include <cassert>
 #include <chrono>
 #include <array>
+#include <iterator>
 #include <cstdlib> // for strtoul
 #include <cinttypes>
 
@@ -133,12 +134,16 @@ static size_t read_data(char* buffer, size_t size, size_t nitems, void* userdata
     }
 
     if (unread <= limit) {
-        std::copy_n(ctx->first.begin() + ctx->second, unread, buffer);
+        auto from = ctx->first.begin();
+        std::advance(from, ctx->second);
+        std::copy_n(from, unread, buffer);
         ctx->second += unread;
         return unread;
     }
 
-    std::copy_n(ctx->first.begin() + ctx->second, limit, buffer);
+    auto from = ctx->first.begin();
+    std::advance(from, ctx->second);
+    std::copy_n(from, limit, buffer);
     ctx->second += limit;
     return limit;
 }


### PR DESCRIPTION
Disabled the parameters easily swappable warning because there isn't an easy way to fix that in C++ without introducing another library or a lot of boilerplate code. The code is small enough to not warrant introducing solutions to avoid that warnings.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
