### PR TITLE
Making libbacktrace optional

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -47,8 +47,29 @@ endif()
 
 target_include_directories(${PROJECT_NAME} PRIVATE ${CURL_INCLUDE_DIRS})
 
-find_package(Backtrace REQUIRED)
-target_link_libraries(${PROJECT_NAME} PRIVATE ${Backtrace_LIBRARIES})
+find_package(Backtrace QUIET)
+if (${Backtrace_FOUND})
+    target_link_libraries(${PROJECT_NAME} PRIVATE ${Backtrace_LIBRARIES})
+
+    find_library(DW_LIB NAMES dw)
+    if (NOT DW_LIB STREQUAL DW_LIB-NOTFOUND)
+        message("-- Enhanced stack-traces are enabled via libdw: ${DW_LIB}")
+        target_compile_definitions(${PROJECT_NAME} PRIVATE "BACKWARD_HAS_DW=1")
+        target_link_libraries(${PROJECT_NAME} PUBLIC "${DW_LIB}")
+    else()
+        find_library(BFD_LIB NAMES bfd)
+        if (NOT BFD_LIB STREQUAL BFD_LIB-NOTFOUND)
+            message("-- Enhanced stack-traces are enabled via libbfd: ${BFD_LIB}")
+            target_compile_definitions(${PROJECT_NAME} PRIVATE "BACKWARD_HAS_BFD=1")
+            target_link_libraries(${PROJECT_NAME} PRIVATE "${BFD_LIB}")
+        endif()
+    endif()
+
+else()
+    message("-- libbacktrace was not installed. Stacktracing will be disabled")
+    add_definitions(-Dno_backtrace)
+endif()
+
 
 target_compile_options(${PROJECT_NAME} PRIVATE
     "-fno-exceptions"
@@ -60,20 +81,6 @@ target_compile_options(${PROJECT_NAME} PRIVATE
     "-Werror"
     "-Wconversion"
     "-Wno-sign-conversion")
-
-find_library(DW_LIB NAMES dw)
-if (NOT DW_LIB STREQUAL DW_LIB-NOTFOUND)
-    message("-- Enhanced stack-traces are enabled via libdw: ${DW_LIB}")
-    target_compile_definitions(${PROJECT_NAME} PRIVATE "BACKWARD_HAS_DW=1")
-    target_link_libraries(${PROJECT_NAME} PUBLIC "${DW_LIB}")
-else()
-    find_library(BFD_LIB NAMES bfd)
-    if (NOT BFD_LIB STREQUAL BFD_LIB-NOTFOUND)
-        message("-- Enhanced stack-traces are enabled via libbfd: ${BFD_LIB}")
-        target_compile_definitions(${PROJECT_NAME} PRIVATE "BACKWARD_HAS_BFD=1")
-        target_link_libraries(${PROJECT_NAME} PRIVATE "${BFD_LIB}")
-    endif()
-endif()
 
 if (LOG_VERBOSITY)
     target_compile_definitions(${PROJECT_NAME} PRIVATE "AWS_LAMBDA_LOG=${LOG_VERBOSITY}")

--- a/src/backward.cpp
+++ b/src/backward.cpp
@@ -25,13 +25,12 @@
 
 #ifndef no_backtrace
 
-#include "backward.h"
+#    include "backward.h"
 
 namespace backward {
 
 backward::SignalHandling sh;
 
 } // namespace backward
-
 
 #endif

--- a/src/backward.cpp
+++ b/src/backward.cpp
@@ -23,6 +23,8 @@
 // - g++/clang++ -lbfd ...
 // #define BACKWARD_HAS_BFD 1
 
+#ifndef no_backtrace
+
 #include "backward.h"
 
 namespace backward {
@@ -30,3 +32,6 @@ namespace backward {
 backward::SignalHandling sh;
 
 } // namespace backward
+
+
+#endif

--- a/src/backward.h
+++ b/src/backward.h
@@ -28,6 +28,10 @@
 #    error "It's not going to compile without a C++ compiler..."
 #endif
 
+#ifdef no_backtrace
+#   pragma message "Disabling stacktracing"
+#else
+
 #if defined(BACKWARD_CXX11)
 #elif defined(BACKWARD_CXX98)
 #else
@@ -4538,5 +4542,7 @@ public:
 #endif // BACKWARD_SYSTEM_UNKNOWN
 
 } // namespace backward
+
+#endif /* no_backtrace */
 
 #endif /* H_GUARD */


### PR DESCRIPTION
### *Issue #, if available:*
#124 and #186

### *Description of changes:*
This fix will make libbacktrace optional and allow Alpine 3.17+ users to update their images.
Behaviour will remain unchanged for every other Linux distro.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
