### PR TITLE
Use the Lambda executable as the bootstrap when glibc is not required

### DIFF
--- a/packaging/packager
+++ b/packaging/packager
@@ -171,20 +171,11 @@ exec \$LAMBDA_TASK_ROOT/lib/$PKG_LD --library-path \$LAMBDA_TASK_ROOT/lib \$LAMB
 EOF
 )
 
-bootstrap_script_no_libc=$(cat <<EOF
-#!/bin/bash
-set -euo pipefail
-export AWS_EXECUTION_ENV=lambda-cpp
-export LD_LIBRARY_PATH=\$LD_LIBRARY_PATH:\$LAMBDA_TASK_ROOT/lib
-exec \$LAMBDA_TASK_ROOT/bin/$PKG_BIN_FILENAME \${_HANDLER}
-EOF
-)
-
-cp "$PKG_BIN_PATH" "$PKG_DIR/bin"
 if [[ $INCLUDE_LIBC == true ]]; then
+    cp "$PKG_BIN_PATH" "$PKG_DIR/bin"
     echo -e "$bootstrap_script" > "$PKG_DIR/bootstrap"
 else
-    echo -e "$bootstrap_script_no_libc" > "$PKG_DIR/bootstrap"
+    cp "$PKG_BIN_PATH" "$PKG_DIR/bootstrap"
 fi
 chmod +x "$PKG_DIR/bootstrap"
 # some shenanigans to create the right layout in the zip file without extraneous directories

--- a/tests/resources/lambda_function.cpp
+++ b/tests/resources/lambda_function.cpp
@@ -41,12 +41,9 @@ int main(int argc, char* argv[])
     handlers.emplace("binary_response", binary_response);
     handlers.emplace("crash_backtrace", crash_backtrace);
 
-    if (argc < 2) {
-        aws::logging::log_error("lambda_fun", "Missing handler argument. Exiting.");
-        return -1;
-    }
-
-    auto it = handlers.find(argv[1]);
+    // Read the handler from the environment variable
+    const char* handler_name = std::getenv("_HANDLER");
+    auto it = handlers.find(handler_name == nullptr ? "" : handler_name);
     if (it == handlers.end()) {
         aws::logging::log_error("lambda_fun", "Handler %s not found. Exiting.", argv[1]);
         return -2;


### PR DESCRIPTION
This change decreases the cold-start times for functions developed on/for the same environment in which Lambda executes the binary.

When building the function on `provided:al2` we don't need to package libc, and also we don't need the bootstrap bash script to start the executable.
Previously, at the time it was initially written, it was important to have `LD_LIBRARY_PATH` in the environment. But now Lambda environment already sets that for us.

In my own measurements, this takes cold-start time down by about 5ms, bringing it to equivalence with Rust.
See https://maxday.github.io/lambda-perf/