### PR TITLE
Remove Extra Space Before "stackTrace" in Error Payload JSON

### DIFF
--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -527,7 +527,7 @@ invocation_response invocation_response::failure(std::string const& error_messag
     r.m_success = false;
     r.m_content_type = "application/json";
     r.m_payload = R"({"errorMessage":")" + json_escape(error_message) + R"(","errorType":")" + json_escape(error_type) +
-                  R"(", "stackTrace":[]})";
+                  R"(","stackTrace":[]})";
     return r;
 }
 


### PR DESCRIPTION
# Summery
This PR addresses the issue reported in #197 regarding the unnecessary space found before the "stackTrace" key in the generated JSON error payload. The presence of this space affects the consistency of the JSON formatting without impacting the functionality or parseability of the output. This minor change aims to enhance the readability and the overall quality of the code by maintaining a consistent JSON format.

# Changes
The extra space before the "stackTrace" key in the JSON string construction has been removed.
## Before
```
R"(", "stackTrace":[]})";
```
## After
```
R"(","stackTrace":[]})";
```
