### PR TITLE
fix the failure when the dynamic loader path is different from the ones in libc

### DIFF
--- a/packaging/packager
+++ b/packaging/packager
@@ -128,21 +128,20 @@ do
         continue
     fi
 
-    filename=$(basename "$i")
-    if [[ -z "${filename##ld-*}" ]]; then
-        PKG_LD=$filename # Use this file as the loader
-        cp "$i" "$PKG_DIR/lib"
-    fi
-
-    # Do not copy libc files which are directly linked
+    # Do not copy libc files which are directly linked unless it's the dynamic loader
     if hasElement "$i" "${libc_libs[@]}"; then
+        filename=$(basename "$i")
+        if [[ -z "${filename##ld-*}" ]]; then
+            PKG_LD=$filename # Use this file as the loader
+            cp "$i" "$PKG_DIR/lib"
+        fi
         continue
     fi
 
     cp "$i" $PKG_DIR/lib
 done
 
-if [[ $INCLUDE_LIBC == true ]]; then
+if [[ $INCLUDE_LIBC == true || -z "$PKG_LD" ]]; then
     for i in "${libc_libs[@]}"
     do
         filename=$(basename "$i")
@@ -152,10 +151,15 @@ if [[ $INCLUDE_LIBC == true ]]; then
             if [[ -z "$PKG_LD" ]]; then 
                 PKG_LD=$filename
                 cp "$i" "$PKG_DIR/lib" # we want to follow the symlink (default behavior)
+                if [[ $INCLUDE_LIBC != true ]]; then
+                    break
+                fi
             fi
             continue # We don't want the dynamic loader's symlink because its target is an absolute path (/lib/ld-*).
         fi
-        cp --no-dereference "$i" "$PKG_DIR/lib"
+        if [[ $INCLUDE_LIBC == true ]]; then
+            cp --no-dereference "$i" "$PKG_DIR/lib"
+        fi
     done
 fi
 


### PR DESCRIPTION
*Issue #, if available:*
In Ubuntu 24.04, the dynamic loader path from the ldd command is different from the paths in dpkg-quey. 
![image](https://github.com/user-attachments/assets/0d81177a-ba11-4977-8520-a8646da4fe55)
So the current packaging process fails because the packager could not find the dynamic loader.

*Description of changes:*
The PR changes it to using the dynamic loader from libc if the one from ldd is not found in libc.

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
