### PR TITLE
apply patch add-tenant-id maintained by other RICs

### DIFF
--- a/include/aws/lambda-runtime/runtime.h
+++ b/include/aws/lambda-runtime/runtime.h
@@ -62,6 +62,11 @@ struct invocation_request {
     std::chrono::time_point<std::chrono::system_clock> deadline;
 
     /**
+     * The Tenant ID of the current invocation.
+     */
+    std::string tenant_id;
+
+    /**
      * The number of milliseconds left before lambda terminates the current execution.
      */
     inline std::chrono::milliseconds get_time_remaining() const;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -41,6 +41,7 @@ static constexpr auto CLIENT_CONTEXT_HEADER = "lambda-runtime-client-context";
 static constexpr auto COGNITO_IDENTITY_HEADER = "lambda-runtime-cognito-identity";
 static constexpr auto DEADLINE_MS_HEADER = "lambda-runtime-deadline-ms";
 static constexpr auto FUNCTION_ARN_HEADER = "lambda-runtime-invoked-function-arn";
+static constexpr auto TENANT_ID_HEADER = "lambda-runtime-aws-tenant-id";
 
 enum Endpoints {
     INIT,
@@ -299,6 +300,11 @@ runtime::next_outcome runtime::get_next()
     out = resp.get_header(FUNCTION_ARN_HEADER);
     if (out.is_success()) {
         req.function_arn = std::move(out).get_result();
+    }
+
+    out = resp.get_header(TENANT_ID_HEADER);
+    if (out.is_success()) {
+        req.tenant_id = std::move(out).get_result();
     }
 
     out = resp.get_header(DEADLINE_MS_HEADER);


### PR DESCRIPTION
*Issue #, if available:*

Related to #209

*Description of changes:*

I was doing something silly with the Python RIC, and that involved updating it's aws-lambda-cpp version to 0.2.10 (from 0.2.6), and fixing a couple of the patch files that didn't apply. Since I fixed those patches, it seemed fair to apply them upstream too.

This change is effectively the application of the patch file https://github.com/aws/aws-lambda-python-runtime-interface-client/blob/main/deps/patches/aws-lambda-cpp-add-tenant-id.patch, but with changes since this part of the code now uses `std::move`


By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
