### PR TITLE
apply patch add-content-type maintained by other RICs

### DIFF
--- a/include/aws/http/response.h
+++ b/include/aws/http/response.h
@@ -38,6 +38,7 @@ public:
     inline void set_response_code(aws::http::response_code c);
     inline void set_content_type(char const* ct);
     inline std::string const& get_body() const;
+    inline std::string const& get_content_type() const;
 
 private:
     response_code m_response_code;
@@ -139,6 +140,12 @@ inline std::string const& response::get_body() const
 {
     return m_body;
 }
+
+inline std::string const& response::get_content_type() const
+{
+    return m_content_type;
+}
+
 inline void response::add_header(std::string name, std::string const& value)
 {
     std::transform(name.begin(), name.end(), name.begin(), ::tolower);

--- a/include/aws/lambda-runtime/runtime.h
+++ b/include/aws/lambda-runtime/runtime.h
@@ -57,6 +57,11 @@ struct invocation_request {
     std::string function_arn;
 
     /**
+     * The Content-type of the current invocation.
+     */
+    std::string content_type;
+
+    /**
      * Function execution deadline counted in milliseconds since the Unix epoch.
      */
     std::chrono::time_point<std::chrono::system_clock> deadline;

--- a/src/runtime.cpp
+++ b/src/runtime.cpp
@@ -280,6 +280,7 @@ runtime::next_outcome runtime::get_next()
     invocation_request req;
     req.payload = resp.get_body();
     req.request_id = std::move(out).get_result();
+    req.content_type = resp.get_content_type();
 
     out = resp.get_header(TRACE_ID_HEADER);
     if (out.is_success()) {


### PR DESCRIPTION
*Issue #, if available:*

Related to https://github.com/awslabs/aws-lambda-cpp/issues/209

*Description of changes:*

I was doing something silly with the Python RIC, and that involved updating it's aws-lambda-cpp version to 0.2.10 (from 0.2.6), and fixing a couple of the patch files that didn't apply. Since I fixed those patches, it seemed fair to apply them upstream too.

This change is the application of the patch file https://github.com/aws/aws-lambda-python-runtime-interface-client/blob/main/deps/patches/aws-lambda-cpp-add-content-type.patch

By submitting this pull request, I confirm that my contribution is made under the terms of the Apache 2.0 license.
